### PR TITLE
fix for omitted accessPoints

### DIFF
--- a/cluster/backup_files.tf
+++ b/cluster/backup_files.tf
@@ -3,7 +3,7 @@ locals {
   backup_file_systems = [
     for application in var.applications :
     application.name
-    if length(coalesce(application.accessPoints, [])) != 0
+    if contains(keys(application), "accessPoints")
   ]
 }
 


### PR DESCRIPTION
This will check the yaml structure for the accessPoints key and only add the applications to the list that contain that key.
This will fix the error `The argument "volume.0.efs_volume_configuration.0.file_system_id" is required, but no definition was found.` when running against applications that do not have accessPoints defined.
This will still error if accessPoints are defined - but the list is empty.  However this does not seem worthwhile to solve for as the solution would be to remove the empty list from yaml