### PR TITLE
public_subnets is the proper output for this module

### DIFF
--- a/cluster/outputs.tf
+++ b/cluster/outputs.tf
@@ -107,7 +107,7 @@ output "vpc_id" {
 
 output "public_subnet_ids" {
   description = "List of IDs of public subnets"
-  value       = module.vpc.public_subnet_ids
+  value       = module.vpc.public_subnets
 }
 
 output "availability_zones" {


### PR DESCRIPTION
 public_subnets

Description: List of IDs of public subnets 

https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest?tab=outputs