### PR TITLE
Allow SSO users to see Metric Data

### DIFF
--- a/sso/iam_ecs.tf
+++ b/sso/iam_ecs.tf
@@ -24,7 +24,8 @@ data "aws_iam_policy_document" "ecs_access" {
       "ecs:DescribeClusters",
       "ecs:DescribeServices",
       "ecs:DescribeTaskDefinition",
-      "ecs:DescribeTasks"
+      "ecs:DescribeTasks",
+      "cloudwatch:GetMetricData"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
This will allow SSO Users to View Cloud Watch Metric data - like CPU/Memory usage in the ECS Console