### PR TITLE
Allow autoscaling read access

### DIFF
--- a/sso/iam_ecs.tf
+++ b/sso/iam_ecs.tf
@@ -43,6 +43,18 @@ data "aws_iam_policy_document" "ecs_access" {
       values   = var.ecs_cluster_arns
     }
   }
+
+  statement {
+    sid    = "readAutoScaling"
+    effect = "Allow"
+
+    actions = [
+      "application-autoscaling:DescribeScalableTargets",
+      "application-autoscaling:DescribeScalingActivities"
+    ]
+
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "ecs_access" {


### PR DESCRIPTION
This PR allows access to Application Auto Scaling resources. The primary use case is to view ECS scaling parameters when viewing a service in the AWS console for developers.