### PR TITLE
Deploy ALB in parallel

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,7 +4,6 @@ env:
 definitions:
   terraform: &terraform hashicorp/terraform:1.7.3
   tflint: &tflint ghcr.io/terraform-linters/tflint-bundle
-  nodejs: &nodejs node:18
 
   ecr: &ecr
     ecr#v2.7.0:
@@ -21,6 +20,7 @@ definitions:
     - cluster
     - cluster/application
     - cluster/traefik
+    - cluster/traefik-alb
     - sso
     - tf_mysql_aurora
     - tf_postgresql_aurora

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -20,6 +20,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> 5.0 |
+| <a name="module_alb_log_bucket"></a> [alb\_log\_bucket](#module\_alb\_log\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.0.1 |
 | <a name="module_application"></a> [application](#module\_application) | ./application | n/a |
 | <a name="module_ecs"></a> [ecs](#module\_ecs) | terraform-aws-modules/ecs/aws | ~> 5.7 |
 | <a name="module_endpoints"></a> [endpoints](#module\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | ~> 5.4 |
@@ -30,6 +31,7 @@
 | <a name="module_s3_env"></a> [s3\_env](#module\_s3\_env) | terraform-aws-modules/s3-bucket/aws | ~> 4.0.1  |
 | <a name="module_s3_tfstate"></a> [s3\_tfstate](#module\_s3\_tfstate) | terraform-aws-modules/s3-bucket/aws | ~> 4.0.1 |
 | <a name="module_traefik"></a> [traefik](#module\_traefik) | ./traefik | n/a |
+| <a name="module_traefik_alb"></a> [traefik\_alb](#module\_traefik\_alb) | ./traefik-alb | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.4 |
 
 ## Resources
@@ -117,6 +119,7 @@
 | [aws_iam_role_policy_attachment.terraform_database_locks_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.terraform_database_secrets_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.terraform_database_tfstate_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lb.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb.nlb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_opensearch_domain.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearch_domain) | resource |
 | [aws_route53_record.nlb_ipv4](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -132,12 +135,15 @@
 | [aws_secretsmanager_secret_version.backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.mysql_root_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.postgresql_root_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_security_group.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.memcache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.alb_http_in_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.alb_https_in_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.backups_ssh_out](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ecs_default_efs_out](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ecs_default_http_out_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -147,6 +153,8 @@
 | [aws_security_group_rule.ecs_default_postgresql_in](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ecs_default_postgresql_out](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ecs_default_smtp_out](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ecs_default_traefik_alb_in_80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ecs_default_traefik_alb_out_80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ecs_default_traefik_in_80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ecs_default_traefik_in_extra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ecs_default_traefik_out_80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/cluster/alb.tf
+++ b/cluster/alb.tf
@@ -1,0 +1,60 @@
+# Create S3 log bucket for ALB logs - use random string for unique S3 name
+
+module "alb_log_bucket" {
+  source                        = "terraform-aws-modules/s3-bucket/aws"
+  version                       = "~> 4.0.1"
+  bucket_prefix                 = "${var.name}-alb-logs-"
+  acl                           = "log-delivery-write"
+  force_destroy                 = true
+  attach_lb_log_delivery_policy = true
+  control_object_ownership      = true
+  block_public_acls             = true
+  block_public_policy           = true
+  ignore_public_acls            = true
+  restrict_public_buckets       = true
+  object_ownership              = "ObjectWriter"
+
+  attach_deny_insecure_transport_policy = true
+  attach_require_latest_tls_policy      = true
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  # Expire log entries per our retention policy
+  lifecycle_rule = [
+    {
+      id      = "expire-log-entries"
+      enabled = true
+
+      expiration = [
+        { days = var.logs.retention }
+      ]
+    }
+  ]
+
+  tags = var.tags
+}
+
+resource "aws_lb" "alb" {
+  name_prefix        = var.name
+  load_balancer_type = "application"
+
+  subnets         = module.vpc.public_subnets
+  security_groups = [aws_security_group.alb.id]
+  ip_address_type = "dualstack"
+
+  enable_deletion_protection = false
+
+  access_logs {
+    bucket  = module.alb_log_bucket.s3_bucket_id
+    prefix  = "logs"
+    enabled = true
+  }
+
+  tags = var.tags
+}

--- a/cluster/security_group_alb.tf
+++ b/cluster/security_group_alb.tf
@@ -1,0 +1,36 @@
+# Security group for the ALB.
+resource "aws_security_group" "alb" {
+  name        = "${var.name}-alb"
+  description = "Security group for the ALB"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = {
+    Name = "${var.name}-alb"
+  }
+}
+
+resource "aws_security_group_rule" "alb_http_in_all" {
+  security_group_id = aws_security_group.alb.id
+  description       = "Allows arbitrary HTTP inbound"
+
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+}
+
+resource "aws_security_group_rule" "alb_https_in_all" {
+  security_group_id = aws_security_group.alb.id
+  description       = "Allows arbitrary HTTPS inbound"
+
+  type      = "ingress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+}

--- a/cluster/security_group_ecs.tf
+++ b/cluster/security_group_ecs.tf
@@ -8,6 +8,7 @@ resource "aws_security_group" "ecs" {
     Name = "${var.name}-ecs-application"
   }
 }
+
 resource "aws_security_group_rule" "ecs_default_http_out_all" {
   security_group_id = aws_security_group.ecs.id
   description       = "Default access for ECS to HTTP outbound"
@@ -56,6 +57,26 @@ resource "aws_security_group_rule" "ecs_default_traefik_in_80" {
 resource "aws_security_group_rule" "ecs_default_traefik_out_80" {
   description              = "Egress from Traefik to ECS (port 80)"
   security_group_id        = module.traefik.security_group_id
+  type                     = "egress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs.id
+}
+
+resource "aws_security_group_rule" "ecs_default_traefik_alb_in_80" {
+  description              = "Ingress from Traefik to ECS (port 80)"
+  security_group_id        = aws_security_group.ecs.id
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = module.traefik_alb.security_group_id
+}
+
+resource "aws_security_group_rule" "ecs_default_traefik_alb_out_80" {
+  description              = "Egress from Traefik to ECS (port 80)"
+  security_group_id        = module.traefik_alb.security_group_id
   type                     = "egress"
   from_port                = 80
   to_port                  = 80

--- a/cluster/traefik-alb/.terraform-docs.yaml
+++ b/cluster/traefik-alb/.terraform-docs.yaml
@@ -1,0 +1,13 @@
+formatter: markdown table
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+sort:
+  enabled: true
+  by: required

--- a/cluster/traefik-alb/.tflint.hcl
+++ b/cluster/traefik-alb/.tflint.hcl
@@ -1,0 +1,29 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "aws" {
+  enabled = true
+}
+
+rule "terraform_comment_syntax" {
+  enabled = true
+}
+
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+
+rule "terraform_documented_variables" {
+  enabled = true
+}
+
+rule "terraform_naming_convention" {
+  enabled = true
+  format  = "snake_case"
+}
+
+rule "terraform_standard_module_structure" {
+  enabled = true
+}

--- a/cluster/traefik-alb/README.md
+++ b/cluster/traefik-alb/README.md
@@ -1,0 +1,85 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.37 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.37 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_s3_traefik"></a> [s3\_traefik](#module\_s3\_traefik) | terraform-aws-modules/s3-bucket/aws | ~> 4.0.1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_appautoscaling_policy.traefik](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_policy) | resource |
+| [aws_appautoscaling_target.traefik](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
+| [aws_cloudwatch_log_group.traefik](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_ecs_service.traefik](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.traefik](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_policy.traefik_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.traefik_exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.traefik_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.traefik_exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.traefik_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lb_listener.traefik_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.traefik_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener_certificate.traefik_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate) | resource |
+| [aws_lb_target_group.traefik_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_s3_object.traefik_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
+| [aws_security_group.traefik](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.alb_traefik_in_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.alb_traefik_in_piong](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.alb_traefik_out_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.alb_traefik_out_ping](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.traefik_https_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_iam_policy_document.ecs_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.traefik_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_acm_default_cert_arn"></a> [acm\_default\_cert\_arn](#input\_acm\_default\_cert\_arn) | ARN of the ACM certificate to apply to the HTTPS listener | `string` | n/a | yes |
+| <a name="input_alb_arn"></a> [alb\_arn](#input\_alb\_arn) | ARN of the application load balancer Traefik will be accessed from | `string` | n/a | yes |
+| <a name="input_alb_security_group_id"></a> [alb\_security\_group\_id](#input\_alb\_security\_group\_id) | ID of the ALB's security group | `string` | n/a | yes |
+| <a name="input_cloudwatch_log_retention"></a> [cloudwatch\_log\_retention](#input\_cloudwatch\_log\_retention) | Number of days to retain logs in CloudWatch | `number` | n/a | yes |
+| <a name="input_ecs_cluster_name"></a> [ecs\_cluster\_name](#input\_ecs\_cluster\_name) | Name of the ECS cluster in which Traefik will be deployed | `string` | n/a | yes |
+| <a name="input_private_subnets_ids"></a> [private\_subnets\_ids](#input\_private\_subnets\_ids) | IDs of the private subnets in which Traefik will be launched | `list(string)` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC in which Traefik will be deployed | `string` | n/a | yes |
+| <a name="input_acm_extra_cert_arns"></a> [acm\_extra\_cert\_arns](#input\_acm\_extra\_cert\_arns) | List of additional certificates to apply to the HTTPS listener | `list(string)` | `[]` | no |
+| <a name="input_autoscaling_max"></a> [autoscaling\_max](#input\_autoscaling\_max) | Maximum number of Traefik tasks to run | `number` | `4` | no |
+| <a name="input_autoscaling_min"></a> [autoscaling\_min](#input\_autoscaling\_min) | Minimum number of Traefik tasks to run | `number` | `2` | no |
+| <a name="input_configuration_file"></a> [configuration\_file](#input\_configuration\_file) | Full path to a file to be copied into S3 and read | `string` | `null` | no |
+| <a name="input_image_repository"></a> [image\_repository](#input\_image\_repository) | Image repository from which to pull Traefik. Defaults to pulling from the Docker Hub | `string` | `"traefik"` | no |
+| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Version tag of the Traefik container to use | `string` | `"latest"` | no |
+| <a name="input_task_cpu"></a> [task\_cpu](#input\_task\_cpu) | CPU allocation for the ECS task | `number` | `256` | no |
+| <a name="input_task_memory"></a> [task\_memory](#input\_task\_memory) | Memory allocation for the ECS task | `number` | `512` | no |
+| <a name="input_tls_policy"></a> [tls\_policy](#input\_tls\_policy) | TLS policy to apply to the HTTPS listener | `string` | `"ELBSecurityPolicy-TLS-1-2-2017-01"` | no |
+| <a name="input_traefik_access_logs"></a> [traefik\_access\_logs](#input\_traefik\_access\_logs) | Whether or not to enable access logging by Traefik | `bool` | `false` | no |
+| <a name="input_traefik_log_level"></a> [traefik\_log\_level](#input\_traefik\_log\_level) | Log level for Traefik | `string` | `"ERROR"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_http_lb_listener_arn"></a> [http\_lb\_listener\_arn](#output\_http\_lb\_listener\_arn) | The Traefik HTTP Listener ARN |
+| <a name="output_http_target_group_arn"></a> [http\_target\_group\_arn](#output\_http\_target\_group\_arn) | The Traefik HTTP Target |
+| <a name="output_https_lb_listener_arn"></a> [https\_lb\_listener\_arn](#output\_https\_lb\_listener\_arn) | The Traefik HTTPS Listener ARN |
+| <a name="output_https_target_group_arn"></a> [https\_target\_group\_arn](#output\_https\_target\_group\_arn) | The Traefik HTTPS Target |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The Security Group IP of the Traefik ECS Security Group |
+| <a name="output_traefik_ecs_service_id"></a> [traefik\_ecs\_service\_id](#output\_traefik\_ecs\_service\_id) | The Traefik ECS Service ID |
+| <a name="output_traefik_ecs_task_arn"></a> [traefik\_ecs\_task\_arn](#output\_traefik\_ecs\_task\_arn) | The Traefik ECS Task ARN |
+| <a name="output_traefik_ecs_task_revision"></a> [traefik\_ecs\_task\_revision](#output\_traefik\_ecs\_task\_revision) | The Traefik ECS Task Revision |
+<!-- END_TF_DOCS -->

--- a/cluster/traefik-alb/iam.tf
+++ b/cluster/traefik-alb/iam.tf
@@ -1,0 +1,67 @@
+# Create IAM Roles and Policies
+data "aws_iam_policy_document" "ecs_assume" {
+  version = "2012-10-17"
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# Empty execution role; Traefik does not have any need for runtime setup beyond the default
+resource "aws_iam_role" "traefik_exec" {
+  name               = "${var.ecs_cluster_name}-TraefikALBExecution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "traefik_exec" {
+  role       = aws_iam_role.traefik_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Task role with access to ECS resources
+resource "aws_iam_role" "traefik_task" {
+  name               = "${var.ecs_cluster_name}-TraefikALBTask"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+}
+
+data "aws_iam_policy_document" "traefik_policy" {
+  statement {
+    sid    = "serviceDiscovery"
+    effect = "Allow"
+
+    actions = [
+      "ecs:ListClusters",
+      "ecs:DescribeClusters",
+      "ecs:ListTasks",
+      "ecs:DescribeTasks",
+      "ecs:DescribeContainerInstances",
+      "ecs:DescribeTaskDefinition",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "configurationDiscovery"
+    effect = "Allow"
+
+    actions   = ["s3:GetObject"]
+    resources = ["${module.s3_traefik.s3_bucket_arn}/configuration.yaml"]
+  }
+}
+
+resource "aws_iam_policy" "traefik_policy" {
+  name   = "${var.ecs_cluster_name}-TraefikALBECSAccess"
+  policy = data.aws_iam_policy_document.traefik_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "traefik_policy" {
+  role       = aws_iam_role.traefik_task.name
+  policy_arn = aws_iam_policy.traefik_policy.arn
+}

--- a/cluster/traefik-alb/main.tf
+++ b/cluster/traefik-alb/main.tf
@@ -1,0 +1,7 @@
+data "aws_region" "current" {}
+
+resource "aws_cloudwatch_log_group" "traefik" {
+  name = "/${var.ecs_cluster_name}/services/traefik-alb"
+
+  retention_in_days = var.cloudwatch_log_retention
+}

--- a/cluster/traefik-alb/outputs.tf
+++ b/cluster/traefik-alb/outputs.tf
@@ -1,0 +1,40 @@
+# Module Outputs
+output "security_group_id" {
+  value       = aws_security_group.traefik.id
+  description = "The Security Group IP of the Traefik ECS Security Group"
+}
+
+output "http_target_group_arn" {
+  value       = aws_lb_target_group.traefik_http.arn
+  description = "The Traefik HTTP Target"
+}
+
+output "https_target_group_arn" {
+  value       = aws_lb_target_group.traefik_https.arn
+  description = "The Traefik HTTPS Target"
+}
+
+output "http_lb_listener_arn" {
+  value       = aws_lb_listener.traefik_http.arn
+  description = "The Traefik HTTP Listener ARN"
+}
+
+output "https_lb_listener_arn" {
+  value       = aws_lb_listener.traefik_https.arn
+  description = "The Traefik HTTPS Listener ARN"
+}
+
+output "traefik_ecs_task_arn" {
+  value       = aws_ecs_task_definition.traefik.arn
+  description = "The Traefik ECS Task ARN"
+}
+
+output "traefik_ecs_task_revision" {
+  value       = aws_ecs_task_definition.traefik.revision
+  description = "The Traefik ECS Task Revision"
+}
+
+output "traefik_ecs_service_id" {
+  value       = aws_ecs_service.traefik.id
+  description = "The Traefik ECS Service ID"
+}

--- a/cluster/traefik-alb/providers.tf
+++ b/cluster/traefik-alb/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.37"
+    }
+  }
+}

--- a/cluster/traefik-alb/s3.tf
+++ b/cluster/traefik-alb/s3.tf
@@ -1,0 +1,36 @@
+module "s3_traefik" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 4.0.1"
+
+  bucket_prefix = "${var.ecs_cluster_name}-traefik-"
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  object_ownership = "BucketOwnerEnforced"
+
+  attach_deny_insecure_transport_policy = true
+  attach_require_latest_tls_policy      = true
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_object" "traefik_configuration" {
+  count = var.configuration_file == null ? 0 : 1
+
+  bucket = module.s3_traefik.s3_bucket_id
+  key    = "configuration.yaml"
+
+  content_type = "application/yaml"
+
+  source = var.configuration_file
+  etag   = filemd5(var.configuration_file)
+}

--- a/cluster/traefik-alb/security_group.tf
+++ b/cluster/traefik-alb/security_group.tf
@@ -1,0 +1,70 @@
+# Create Security groups
+resource "aws_security_group" "traefik" {
+  name        = "${var.ecs_cluster_name}-traefik-alb"
+  description = "Security group for the Traefik reverse proxy"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.ecs_cluster_name}-traefik-alb"
+  }
+}
+
+resource "aws_security_group_rule" "traefik_https_egress" {
+  description       = "Allows outbound HTTPS (needed to pull Docker images)"
+  security_group_id = aws_security_group.traefik.id
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+}
+
+
+resource "aws_security_group_rule" "alb_traefik_out_http" {
+  security_group_id = var.alb_security_group_id
+  description       = "Egress from the ALB to Traefik (port 80)"
+
+  type      = "egress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  source_security_group_id = aws_security_group.traefik.id
+}
+
+resource "aws_security_group_rule" "alb_traefik_in_http" {
+  security_group_id = aws_security_group.traefik.id
+  description       = "Ingress from the ALB to Traefik (port 80)"
+
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  source_security_group_id = var.alb_security_group_id
+}
+
+resource "aws_security_group_rule" "alb_traefik_out_ping" {
+  security_group_id = var.alb_security_group_id
+  description       = "Egress from the ALB to Traefik (port 8080)"
+
+  type      = "egress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  source_security_group_id = aws_security_group.traefik.id
+}
+
+resource "aws_security_group_rule" "alb_traefik_in_piong" {
+  security_group_id = aws_security_group.traefik.id
+  description       = "Ingress from the ALB to Traefik (port 8080)"
+
+  type      = "ingress"
+  from_port = 80
+  to_port   = 80
+  protocol  = "tcp"
+
+  source_security_group_id = var.alb_security_group_id
+}

--- a/cluster/traefik-alb/service.tf
+++ b/cluster/traefik-alb/service.tf
@@ -1,0 +1,55 @@
+# Create ECS Service
+resource "aws_ecs_service" "traefik" {
+  name            = "${var.ecs_cluster_name}-traefik-alb"
+  cluster         = var.ecs_cluster_name
+  task_definition = aws_ecs_task_definition.traefik.arn
+  launch_type     = "FARGATE"
+
+  desired_count = var.autoscaling_min
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.traefik_http.id
+    container_name   = "traefik"
+    container_port   = 80
+  }
+
+  network_configuration {
+    subnets         = var.private_subnets_ids
+    security_groups = [aws_security_group.traefik.id]
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+}
+
+# Create an autoscaling target for the Traefik service
+resource "aws_appautoscaling_target" "traefik" {
+  # Tell autoscaling which AWS service resource this target is for.
+  resource_id        = "service/${var.ecs_cluster_name}/${aws_ecs_service.traefik.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+
+  min_capacity = var.autoscaling_min
+  max_capacity = var.autoscaling_max
+}
+
+# Define a CPU-based scaling policy. Autoscaling will attempt to maintain around 30% CPU
+# utilization for the Traefik service.
+resource "aws_appautoscaling_policy" "traefik" {
+  name        = "${var.ecs_cluster_name}-traefik-alb-autoscaling"
+  policy_type = "TargetTrackingScaling"
+
+  # Apply this policy to the traefik autoscaling target
+  resource_id        = aws_appautoscaling_target.traefik.id
+  scalable_dimension = aws_appautoscaling_target.traefik.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.traefik.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value = 30
+
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+  }
+}

--- a/cluster/traefik-alb/target_group.tf
+++ b/cluster/traefik-alb/target_group.tf
@@ -1,0 +1,58 @@
+# Listener: HTTP (redirects to HTTPS)
+
+resource "aws_lb_listener" "traefik_http" {
+  load_balancer_arn = var.alb_arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = 443
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+# Target group and listeners: HTTPS
+
+resource "aws_lb_listener" "traefik_https" {
+  load_balancer_arn = var.alb_arn
+  port              = 443
+  protocol          = "TLS"
+  ssl_policy        = var.tls_policy
+  certificate_arn   = var.acm_default_cert_arn
+
+  default_action {
+    target_group_arn = aws_lb_target_group.traefik_http.id
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener_certificate" "traefik_https" {
+  for_each = toset(var.acm_extra_cert_arns)
+
+  listener_arn    = aws_lb_listener.traefik_https.arn
+  certificate_arn = each.key
+}
+
+resource "aws_lb_target_group" "traefik_http" {
+  name = "${var.ecs_cluster_name}-traefik-alb"
+
+  port              = 80
+  protocol          = "HTTP"
+  target_type       = "ip"
+  proxy_protocol_v2 = true
+  vpc_id            = var.vpc_id
+
+  # Hit the built-in /ping endpoint for ALB health checks
+  health_check {
+    enabled  = true
+    interval = 10
+    port     = 8080
+    path     = "/ping"
+    protocol = "HTTP"
+  }
+}

--- a/cluster/traefik-alb/task_definition.tf
+++ b/cluster/traefik-alb/task_definition.tf
@@ -1,0 +1,134 @@
+resource "aws_ecs_task_definition" "traefik" {
+  family = "${var.ecs_cluster_name}-traefik-alb"
+
+  task_role_arn            = aws_iam_role.traefik_task.arn
+  execution_role_arn       = aws_iam_role.traefik_exec.arn
+  requires_compatibilities = ["FARGATE"]
+
+  cpu          = var.task_cpu
+  memory       = var.task_memory
+  network_mode = "awsvpc"
+
+  container_definitions = jsonencode([
+    {
+      name  = "startup"
+      image = "public.ecr.aws/aws-cli/aws-cli:latest"
+
+      # This is a non-essential container (it's only for startup)
+      essential = false
+
+      entryPoint = [
+        "/bin/bash",
+        "-ec",
+        var.configuration_file == null ? "echo 'No configuration to download.'" : (
+          <<-EOF
+            aws s3 --only-show-errors cp s3://${module.s3_traefik.s3_bucket_id}/configuration.yaml /mnt/configuration/configuration.yaml
+            echo 'Downloaded configuration.'
+          EOF
+        )
+      ]
+
+      environment = [
+        {
+          # Trick ECS into updating the task definition whenever the ETag of the configuration file changes
+          name  = "_FORCE_TASK_REFRESH",
+          value = try(aws_s3_object.traefik_configuration[0].etag, "0")
+        }
+      ]
+
+      mountPoints = [
+        {
+          sourceVolume  = "configuration"
+          containerPath = "/mnt/configuration"
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.traefik.name
+          awslogs-region        = data.aws_region.current.name
+          awslogs-stream-prefix = "startup"
+        }
+      }
+    },
+    {
+      name  = "traefik"
+      image = "${var.image_repository}:${var.image_tag}"
+
+      entryPoint = ["traefik"]
+
+      command = [
+        # Log in JSON format for structured CloudWatch ingestion
+        "--log.format=json",
+
+        # Enable or disable access logs per the variable
+        "--accesslog=${var.traefik_access_logs}",
+
+        # Tell Traefik which region it's in
+        "--providers.ecs.region=${data.aws_region.current.name}",
+
+        # Force discovery only for this cluster
+        "--providers.ecs.autoDiscoverClusters=false",
+        "--providers.ecs.clusters=${var.ecs_cluster_name}",
+
+        # Don't make services accessible by default
+        "--providers.ecs.exposedByDefault=false",
+
+        # Watch the /mnt/configuration directory for configuration; this always
+        # works because an empty directory won't make Traefik do much extra
+        # work.
+        "--providers.file.directory=/mnt/configuration",
+
+        # Set the log level
+        "--log.level=${var.traefik_log_level}",
+
+        # Listen for HTTP traffic on port 80
+        "--entryPoints.websecure.address=:80",
+
+        # Allow the ping endpoint for ALB health checks
+        "--ping",
+      ]
+
+      mountPoints = [
+        {
+          sourceVolume  = "configuration"
+          containerPath = "/mnt/configuration"
+          readOnly      = true
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.traefik.name
+          awslogs-region        = data.aws_region.current.name
+          awslogs-stream-prefix = "traefik"
+        }
+      }
+
+      dependsOn = [
+        {
+          # Force ECS to wait for the configuration to be downloaded into the
+          # shared volume before doing anything (if there's no configuration to
+          # download, the startup container will exit immediately).
+          containerName = "startup"
+          condition     = "COMPLETE"
+        }
+      ]
+
+      portMappings = [
+        { containerPort = 80 },
+        { containerPort = 8080 },
+      ]
+    }
+  ])
+
+  volume {
+    # Allocate an empty directory to share the configuration file between
+    # Traefik and the AWS CLI startup container.
+    name = "configuration"
+  }
+}

--- a/cluster/traefik-alb/variables.tf
+++ b/cluster/traefik-alb/variables.tf
@@ -1,0 +1,108 @@
+variable "vpc_id" {
+  description = "ID of the VPC in which Traefik will be deployed"
+  type        = string
+}
+
+variable "alb_arn" {
+  description = "ARN of the application load balancer Traefik will be accessed from"
+  type        = string
+}
+
+variable "acm_default_cert_arn" {
+  description = "ARN of the ACM certificate to apply to the HTTPS listener"
+  type        = string
+}
+
+variable "acm_extra_cert_arns" {
+  description = "List of additional certificates to apply to the HTTPS listener"
+  type        = list(string)
+  default     = []
+}
+
+variable "tls_policy" {
+  description = "TLS policy to apply to the HTTPS listener"
+  type        = string
+  default     = "ELBSecurityPolicy-TLS-1-2-2017-01"
+}
+
+variable "ecs_cluster_name" {
+  description = "Name of the ECS cluster in which Traefik will be deployed"
+  type        = string
+}
+
+variable "cloudwatch_log_retention" {
+  description = "Number of days to retain logs in CloudWatch"
+  type        = number
+}
+
+variable "alb_security_group_id" {
+  description = "ID of the ALB's security group"
+  type        = string
+}
+
+variable "private_subnets_ids" {
+  description = "IDs of the private subnets in which Traefik will be launched"
+  type        = list(string)
+}
+
+variable "task_cpu" {
+  description = "CPU allocation for the ECS task"
+  type        = number
+  nullable    = false
+  default     = 256
+}
+
+variable "task_memory" {
+  description = "Memory allocation for the ECS task"
+  type        = number
+  nullable    = false
+  default     = 512
+}
+
+variable "autoscaling_min" {
+  description = "Minimum number of Traefik tasks to run"
+  type        = number
+  nullable    = false
+  default     = 2
+}
+
+variable "autoscaling_max" {
+  description = "Maximum number of Traefik tasks to run"
+  type        = number
+  nullable    = false
+  default     = 4
+}
+
+variable "image_repository" {
+  description = "Image repository from which to pull Traefik. Defaults to pulling from the Docker Hub"
+  type        = string
+  nullable    = false
+  default     = "traefik"
+}
+
+variable "image_tag" {
+  description = "Version tag of the Traefik container to use"
+  type        = string
+  nullable    = false
+  default     = "latest"
+}
+
+variable "traefik_log_level" {
+  description = "Log level for Traefik"
+  type        = string
+  nullable    = false
+  default     = "ERROR"
+}
+
+variable "traefik_access_logs" {
+  description = "Whether or not to enable access logging by Traefik"
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+variable "configuration_file" {
+  description = "Full path to a file to be copied into S3 and read"
+  type        = string
+  default     = null
+}

--- a/cluster/traefik.tf
+++ b/cluster/traefik.tf
@@ -1,3 +1,4 @@
+# Legacy: Traefik routing from behind an NLB
 module "traefik" {
   source = "./traefik"
 
@@ -9,6 +10,34 @@ module "traefik" {
   public_subnets_ipv6 = module.vpc.public_subnets_ipv6_cidr_blocks
 
   nlb_arn              = aws_lb.nlb.arn
+  acm_default_cert_arn = module.acm.acm_certificate_arn
+  acm_extra_cert_arns  = var.acm.certificates
+
+  image_repository = var.traefik.repository
+  image_tag        = var.traefik.tag
+
+  traefik_log_level = var.traefik.log_level
+
+  configuration_file = var.traefik.config_file
+
+  autoscaling_min = var.traefik.min_capacity
+  autoscaling_max = var.traefik.max_capacity
+
+  cloudwatch_log_retention = var.logs.retention
+}
+
+# Traefik routing from behind an ALB
+module "traefik_alb" {
+  source = "./traefik-alb"
+
+  ecs_cluster_name = module.ecs.cluster_name
+
+  vpc_id              = module.vpc.vpc_id
+  private_subnets_ids = module.vpc.private_subnets
+
+  alb_arn               = aws_lb.alb.arn
+  alb_security_group_id = aws_security_group.alb.id
+
   acm_default_cert_arn = module.acm.acm_certificate_arn
   acm_extra_cert_arns  = var.acm.certificates
 

--- a/scripts/update-docs.sh
+++ b/scripts/update-docs.sh
@@ -8,6 +8,7 @@ readonly paths=(
   cluster
   cluster/application
   cluster/traefik
+  cluster/traefik-alb
   tf_mysql_aurora
   tf_postgresql_aurora
 )


### PR DESCRIPTION
This PR deploys an ALB in parallel to the existing NLB. It's the first step of a migration to the ALB in order to better support handling `X-Forwarded-For` headers and other proxy information.