### PR TITLE
Use name instead of name_prefix

### DIFF
--- a/cluster/alb.tf
+++ b/cluster/alb.tf
@@ -41,7 +41,7 @@ module "alb_log_bucket" {
 }
 
 resource "aws_lb" "alb" {
-  name_prefix        = var.name
+  name               = "${var.name}-alb"
   load_balancer_type = "application"
 
   subnets         = module.vpc.public_subnets


### PR DESCRIPTION
Our cluster names are too long for the `name_prefix` attribute, so we have to go with `name`.