### PR TITLE
Fix secret path

### DIFF
--- a/cluster/application/iam_user.tf
+++ b/cluster/application/iam_user.tf
@@ -56,7 +56,7 @@ resource "aws_iam_access_key" "custom" {
 resource "aws_secretsmanager_secret" "iam_credentials" {
   for_each = local.users
 
-  name        = "${local.directory_prefix}/${each.value.env}/iam/${each.value.env}/keys"
+  name        = "${local.directory_prefix}/${each.value.env}/iam/${each.value.user}/keys"
   description = "IAM access keys for the ${each.value.env}/${each.value.user} user"
 
   tags = var.tags


### PR DESCRIPTION
This PR prevents duplicating the environment in the secret identifier, since we might have multiple users per application.