### PR TITLE
Apply tags to AWS resources

### DIFF
--- a/cluster/acm.tf
+++ b/cluster/acm.tf
@@ -20,7 +20,8 @@ module "acm" {
   wait_for_validation = true
   zone_id             = aws_route53_zone.public.id
   validation_method   = "DNS"
-  tags = merge(var.tags, {
+
+  tags = merge(local.tags, {
     Name = "${var.name}.${var.dns.suffix}"
   })
 }

--- a/cluster/alb.tf
+++ b/cluster/alb.tf
@@ -38,7 +38,7 @@ module "alb_log_bucket" {
     }
   ]
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_lb" "alb" {
@@ -57,5 +57,5 @@ resource "aws_lb" "alb" {
     enabled = true
   }
 
-  tags = var.tags
+  tags = local.tags
 }

--- a/cluster/application.tf
+++ b/cluster/application.tf
@@ -18,4 +18,6 @@ module "application" {
   vpc_id                 = module.vpc.vpc_id
   vpc_private_subnets    = module.vpc.private_subnets
   vpc_availability_zones = module.vpc.azs
+
+  tags = local.tags
 }

--- a/cluster/application/cloudwatch.tf
+++ b/cluster/application/cloudwatch.tf
@@ -21,5 +21,7 @@ resource "aws_cloudwatch_log_group" "logs" {
 
   retention_in_days = var.cloudwatch_retention
 
-  tags = var.tags
+  tags = merge(local.tags, {
+    "forumone:environment" = each.value.env
+  })
 }

--- a/cluster/application/dns_private.tf
+++ b/cluster/application/dns_private.tf
@@ -37,7 +37,9 @@ resource "aws_service_discovery_service" "service" {
     failure_threshold = 1
   }
 
-  tags = var.tags
+  tags = merge(local.tags, {
+    "forumone:environment" = each.value.env
+  })
 }
 
 # Create an SSM parameter for the Cloud Map service ARN
@@ -48,5 +50,7 @@ resource "aws_ssm_parameter" "service" {
   type  = "String"
   value = aws_service_discovery_service.service[each.key].arn
 
-  tags = var.tags
+  tags = merge(local.tags, {
+    "forumone:environment" = each.value.env
+  })
 }

--- a/cluster/application/ecr.tf
+++ b/cluster/application/ecr.tf
@@ -4,7 +4,7 @@ resource "aws_ecr_repository" "repository" {
 
   name = "${var.cluster_name}/${var.application.name}/${each.value}"
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_ecr_lifecycle_policy" "repository" {

--- a/cluster/application/efs.tf
+++ b/cluster/application/efs.tf
@@ -68,11 +68,13 @@ module "efs" {
         }
       }
 
-      tags = var.tags
+      tags = merge(local.tags, {
+        "forumone:environment" = each.value.env
+      })
     }
   }
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_ssm_parameter" "efs_id" {
@@ -82,7 +84,7 @@ resource "aws_ssm_parameter" "efs_id" {
   type  = "String"
   value = module.efs[0].id
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_ssm_parameter" "efs_ap_id" {
@@ -92,5 +94,7 @@ resource "aws_ssm_parameter" "efs_ap_id" {
   type  = "String"
   value = module.efs[0].access_points[each.key].id
 
-  tags = var.tags
+  tags = merge(local.tags, {
+    "forumone:environment" = each.value.env
+  })
 }

--- a/cluster/application/iam_role.tf
+++ b/cluster/application/iam_role.tf
@@ -33,7 +33,9 @@ resource "aws_iam_role" "custom" {
 
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
 
-  tags = var.tags
+  tags = merge(local.tags, {
+    "forumone:environment" = each.value.env
+  })
 }
 
 # Store role ARNs as SSM parameters for easier access by downstream deployments
@@ -44,5 +46,7 @@ resource "aws_ssm_parameter" "iam_role_arn" {
   type  = "String"
   value = aws_iam_role.custom[each.key].arn
 
-  tags = var.tags
+  tags = merge(local.tags, {
+    "forumone:environment" = each.value.env
+  })
 }

--- a/cluster/application/iam_user.tf
+++ b/cluster/application/iam_user.tf
@@ -34,7 +34,9 @@ resource "aws_iam_user" "custom" {
 
   name = "${var.cluster_name}-${var.application.name}-${each.value.env}-${each.value.user}"
 
-  tags = var.tags
+  tags = merge(local.tags, {
+    "forumone:environment" = each.value.env
+  })
 }
 
 # Attach the boundary policy
@@ -59,7 +61,9 @@ resource "aws_secretsmanager_secret" "iam_credentials" {
   name        = "${local.directory_prefix}/${each.value.env}/iam/${each.value.user}/keys"
   description = "IAM access keys for the ${each.value.env}/${each.value.user} user"
 
-  tags = var.tags
+  tags = merge(local.tags, {
+    "forumone:environment" = each.value.env
+  })
 }
 
 resource "aws_secretsmanager_secret_version" "iam_credentials" {

--- a/cluster/application/main.tf
+++ b/cluster/application/main.tf
@@ -5,4 +5,9 @@ locals {
   # Shared prefix for any directory-like structure (e.g., CloudWatch or
   # Parameter Store). Use this to avoid introducing potential copy/paste errors.
   directory_prefix = "/${var.cluster_name}/applications/${var.application.name}"
+
+  # Shared tags for all resources
+  tags = merge(var.tags, {
+    "forumone:site" = var.application.name
+  })
 }

--- a/cluster/application/security_group.tf
+++ b/cluster/application/security_group.tf
@@ -14,8 +14,10 @@ resource "aws_security_group" "custom" {
   vpc_id = var.vpc_id
   name   = "${var.cluster_name}-${var.application.name}-${each.value.env}-${each.value.sg}"
 
-  tags = merge(var.tags, {
+  tags = merge(local.tags, {
     Name = "${var.cluster_name} ${var.application.name}: ${each.key}"
+
+    "forumone:environment" = each.value.env
   })
 }
 
@@ -26,5 +28,7 @@ resource "aws_ssm_parameter" "security_group" {
   type  = "String"
   value = aws_security_group.custom[each.key].id
 
-  tags = var.tags
+  tags = merge(local.tags, {
+    "forumone:environment" = each.value.env
+  })
 }

--- a/cluster/auto_files_export.tf
+++ b/cluster/auto_files_export.tf
@@ -67,14 +67,10 @@ resource "aws_ssm_document" "files_export" {
             {
               ResourceType = "instance"
 
-              Tags = [
+              Tags = concat(local.tag_list, [
                 {
                   Key   = "Name"
                   Value = "EFS Export/{{ automation:EXECUTION_ID }}"
-                },
-                {
-                  Key   = "forumone:cluster"
-                  Value = var.name
                 },
                 {
                   Key   = "forumone:site"
@@ -84,7 +80,7 @@ resource "aws_ssm_document" "files_export" {
                   Key   = "forumone:environment"
                   Value = "{{ environment }}"
                 }
-              ]
+              ])
             }
           ]
         }

--- a/cluster/auto_files_import.tf
+++ b/cluster/auto_files_import.tf
@@ -74,14 +74,10 @@ resource "aws_ssm_document" "files_import" {
             {
               ResourceType = "instance"
 
-              Tags = [
+              Tags = concat(local.tag_list, [
                 {
                   Key   = "Name"
                   Value = "EFS Import/{{ automation:EXECUTION_ID }}"
-                },
-                {
-                  Key   = "forumone:cluster"
-                  Value = var.name
                 },
                 {
                   Key   = "forumone:site"
@@ -91,7 +87,7 @@ resource "aws_ssm_document" "files_import" {
                   Key   = "forumone:environment"
                   Value = "{{ environment }}"
                 }
-              ]
+              ])
             }
           ]
         }

--- a/cluster/auto_mysql_export.tf
+++ b/cluster/auto_mysql_export.tf
@@ -68,14 +68,10 @@ resource "aws_ssm_document" "mysql_export" {
             {
               ResourceType = "instance"
 
-              Tags = [
+              Tags = concat(local.tag_list, [
                 {
                   Key   = "Name"
                   Value = "MySQL Export/{{ automation:EXECUTION_ID }}"
-                },
-                {
-                  Key   = "forumone:cluster"
-                  Value = var.name
                 },
                 {
                   Key   = "forumone:site"
@@ -85,7 +81,7 @@ resource "aws_ssm_document" "mysql_export" {
                   Key   = "forumone:environment"
                   Value = "{{ environment }}"
                 }
-              ]
+              ])
             }
           ]
         }

--- a/cluster/auto_mysql_import.tf
+++ b/cluster/auto_mysql_import.tf
@@ -75,14 +75,10 @@ resource "aws_ssm_document" "mysql_import" {
             {
               ResourceType = "instance"
 
-              Tags = [
+              Tags = concat(local.tag_list, [
                 {
                   Key   = "Name"
                   Value = "MySQL Import/{{ automation:EXECUTION_ID }}"
-                },
-                {
-                  Key   = "forumone:cluster"
-                  Value = var.name
                 },
                 {
                   Key   = "forumone:site"
@@ -92,7 +88,7 @@ resource "aws_ssm_document" "mysql_import" {
                   Key   = "forumone:environment"
                   Value = "{{ environment }}"
                 }
-              ]
+              ])
             }
           ]
         }
@@ -159,7 +155,5 @@ resource "aws_ssm_document" "mysql_import" {
     ]
   })
 
-  tags = {
-    "forumone:cluster" = var.name
-  }
+  tags = local.tags
 }

--- a/cluster/backup_database_mysql.tf
+++ b/cluster/backup_database_mysql.tf
@@ -60,7 +60,7 @@ resource "aws_ecs_task_definition" "backup_database_mysql" {
     name = "scratch"
   }
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_scheduler_schedule" "backup_database_mysql" {
@@ -90,6 +90,8 @@ resource "aws_scheduler_schedule" "backup_database_mysql" {
 
       task_count          = 1
       task_definition_arn = aws_ecs_task_definition.backup_database_mysql[0].arn
+
+      tags = local.tags
 
       network_configuration {
         subnets         = module.vpc.private_subnets

--- a/cluster/backup_files.tf
+++ b/cluster/backup_files.tf
@@ -91,7 +91,7 @@ resource "aws_ecs_task_definition" "backup_files" {
     name = "scratch"
   }
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_scheduler_schedule" "backup_files" {
@@ -120,6 +120,8 @@ resource "aws_scheduler_schedule" "backup_files" {
 
       task_count          = 1
       task_definition_arn = aws_ecs_task_definition.backup_files[each.key].arn
+
+      tags = local.tags
 
       network_configuration {
         subnets         = module.vpc.private_subnets

--- a/cluster/backup_iam.tf
+++ b/cluster/backup_iam.tf
@@ -3,6 +3,8 @@ resource "aws_iam_role" "backups_exec" {
   description = "Role to execute the backups tasks"
 
   assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "backups_exec" {
@@ -31,6 +33,8 @@ resource "aws_iam_policy" "backups_credentials" {
   description = "Grants backups tasks access to their SSH key"
 
   policy = data.aws_iam_policy_document.backups_credentials.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "backups_credentials" {
@@ -43,6 +47,8 @@ resource "aws_iam_role" "backups_task" {
   description = "Role for the backups tasks"
 
   assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+
+  tags = local.tags
 }
 
 data "aws_iam_policy_document" "backups_s3" {
@@ -61,6 +67,8 @@ resource "aws_iam_policy" "backups_s3" {
   description = "Grants permission to push backup objects to S3"
 
   policy = data.aws_iam_policy_document.backups_s3.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "backups_s3" {

--- a/cluster/backup_sg.tf
+++ b/cluster/backup_sg.tf
@@ -3,9 +3,9 @@ resource "aws_security_group" "backups" {
   description = "Supplementary security group for backups"
   vpc_id      = module.vpc.vpc_id
 
-  tags = {
+  tags = merge(local.tags, {
     Name = "${var.name}-backups"
-  }
+  })
 }
 
 resource "aws_security_group_rule" "backups_ssh_out" {

--- a/cluster/backup_shared.tf
+++ b/cluster/backup_shared.tf
@@ -9,7 +9,7 @@ resource "aws_secretsmanager_secret" "backups" {
 
   recovery_window_in_days = 0
 
-  tags = merge(var.tags, {
+  tags = merge(local.tags, {
     "f1-internal" = "true"
   })
 }
@@ -26,15 +26,21 @@ resource "aws_secretsmanager_secret_version" "backups" {
 resource "aws_cloudwatch_log_group" "backup_database" {
   name              = "/${var.name}/backups/database"
   retention_in_days = var.logs.retention
+
+  tags = local.tags
 }
 
 resource "aws_cloudwatch_log_group" "backup_files" {
   name              = "/${var.name}/backups/files"
   retention_in_days = var.logs.retention
+
+  tags = local.tags
 }
 
 resource "aws_ecr_repository" "backups" {
   name = "${var.name}/backups"
+
+  tags = local.tags
 }
 
 resource "aws_ecr_lifecycle_policy" "backups" {
@@ -63,10 +69,12 @@ resource "aws_ecr_lifecycle_policy" "backups" {
 
 resource "aws_sqs_queue" "backups_dead_letters" {
   name = "${var.name}-BackupsDeadLetters"
+
+  tags = local.tags
 }
 
 resource "aws_scheduler_schedule_group" "backups" {
   name = "${var.name}-backups"
 
-  tags = var.tags
+  tags = local.tags
 }

--- a/cluster/backup_shared.tf
+++ b/cluster/backup_shared.tf
@@ -10,7 +10,7 @@ resource "aws_secretsmanager_secret" "backups" {
   recovery_window_in_days = 0
 
   tags = merge(local.tags, {
-    "f1-internal" = "true"
+    "forumone:internal" = "true"
   })
 }
 

--- a/cluster/backups_schedule.tf
+++ b/cluster/backups_schedule.tf
@@ -16,6 +16,8 @@ data "aws_iam_policy_document" "events_backups_assume_role" {
 resource "aws_iam_role" "events_backups" {
   name               = "${var.name}-BackupsCron"
   assume_role_policy = data.aws_iam_policy_document.events_backups_assume_role.json
+
+  tags = local.tags
 }
 
 data "aws_iam_policy_document" "events_backups_pass_role" {
@@ -34,6 +36,8 @@ resource "aws_iam_policy" "events_backups_pass_role" {
   description = "Grants EventBridge permission to pass backup roles"
 
   policy = data.aws_iam_policy_document.events_backups_pass_role.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "events_backups_pass_role" {
@@ -55,6 +59,8 @@ data "aws_iam_policy_document" "events_backups_write_dead_letters" {
 resource "aws_iam_policy" "events_backups_write_dead_letters" {
   name   = "${var.name}-BackupsWriteDeadLetters"
   policy = data.aws_iam_policy_document.events_backups_write_dead_letters.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "events_backups_write_dead_letters" {
@@ -83,7 +89,7 @@ resource "aws_iam_policy" "events_backups_run_task" {
   name   = "${var.name}-BackupsRunTask"
   policy = data.aws_iam_policy_document.events_backups_run_task.json
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "events_backups_run_task" {

--- a/cluster/db_create_terraform_iam.tf
+++ b/cluster/db_create_terraform_iam.tf
@@ -20,6 +20,8 @@ resource "aws_iam_role" "terraform_database_exec" {
   name               = "${var.name}-TerraformDatabaseExecution"
   description        = "Role to execute the Terraform-based database initialization"
   assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "terraform_database_exec" {
@@ -32,6 +34,8 @@ resource "aws_iam_policy" "terraform_database_credentials_access" {
   name        = "${var.name}-TerraformDatabaseRootCredsAccess"
   description = "Allows binding the root RDS credentials to the Terraform database task"
   policy      = data.aws_iam_policy_document.terraform_database_credentials_access[0].json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "terraform_database_credentials_access" {
@@ -98,18 +102,24 @@ resource "aws_iam_policy" "terraform_database_tfstate_access" {
   name        = "${var.name}-TerraformDatabaseTFStateAccess"
   description = "Grants access to remote backend S3 bucket/tf_aurora_mysql.tfstate or tf_aurora_postgresql.tfstate"
   policy      = data.aws_iam_policy_document.terraform_database_tfstate_access.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_policy" "terraform_locks_access" {
   name        = "${var.name}-TerraformDatabaseTFLocksAccess"
   description = "Grants access to remote backend Dynamo DB Terraform Locks Table"
   policy      = data.aws_iam_policy_document.terraform_locks_access.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role" "terraform_database_task" {
   name               = "${var.name}-TerraformDatabaseTask"
   description        = "Role for the Terraform-based database initialization process"
   assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "terraform_database_tfstate_access" {
@@ -174,6 +184,8 @@ data "aws_iam_policy_document" "aws_cloudwatch_event_policy" {
 resource "aws_iam_role" "db_scheduled_event_bridge" {
   name               = "${var.name}-terraform-event-bridge-run"
   assume_role_policy = data.aws_iam_policy_document.aws_cloudwatch_event_assume_role.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy" "scheduled_task_cw_event_role_cloudwatch_policy" {

--- a/cluster/db_ecs_event_bridge.tf
+++ b/cluster/db_ecs_event_bridge.tf
@@ -5,6 +5,8 @@ resource "aws_cloudwatch_event_rule" "db_creation" {
   name                = "${var.name}-terraform-database-creation"
   description         = "${var.name} terraform database creation for ECS Fargate"
   schedule_expression = "rate(2 hours)"
+
+  tags = local.tags
 }
 
 resource "aws_cloudwatch_event_target" "mysql_db_creation" {
@@ -19,6 +21,8 @@ resource "aws_cloudwatch_event_target" "mysql_db_creation" {
 
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.terraform_mysql_database_exec[0].arn
+
+    tags = local.tags
 
     network_configuration {
       subnets         = module.vpc.private_subnets
@@ -39,6 +43,8 @@ resource "aws_cloudwatch_event_target" "postgresql_db_creation" {
 
     task_count          = 1
     task_definition_arn = aws_ecs_task_definition.terraform_postgresql_database_exec[0].arn
+
+    tags = local.tags
 
     network_configuration {
       subnets         = module.vpc.private_subnets

--- a/cluster/db_terraform_mysql.tf
+++ b/cluster/db_terraform_mysql.tf
@@ -49,6 +49,7 @@ resource "aws_ecs_task_definition" "terraform_mysql_database_exec" {
         { name = "BACKEND_STORAGE", value = module.s3_tfstate.s3_bucket_id },
         { name = "BACKEND_LOCKS", value = aws_dynamodb_table.terraform_locks.id },
         { name = "TF_VAR_cluster_name", value = module.ecs.cluster_name },
+        { name = "TF_VAR_tags", value = jsonencode(local.tags) },
       ]
 
       secrets = [
@@ -70,4 +71,6 @@ resource "aws_ecs_task_definition" "terraform_mysql_database_exec" {
       }
     }
   ])
+
+  tags = local.tags
 }

--- a/cluster/db_terraform_postgresql.tf
+++ b/cluster/db_terraform_postgresql.tf
@@ -49,6 +49,7 @@ resource "aws_ecs_task_definition" "terraform_postgresql_database_exec" {
         { name = "BACKEND_STORAGE", value = module.s3_tfstate.s3_bucket_id },
         { name = "BACKEND_LOCKS", value = aws_dynamodb_table.terraform_locks.id },
         { name = "TF_VAR_cluster_name", value = module.ecs.cluster_name },
+        { name = "TF_VAR_tags", value = jsonencode(local.tags) },
       ]
 
       secrets = [
@@ -70,4 +71,6 @@ resource "aws_ecs_task_definition" "terraform_postgresql_database_exec" {
       }
     }
   ])
+
+  tags = local.tags
 }

--- a/cluster/db_terraform_shared.tf
+++ b/cluster/db_terraform_shared.tf
@@ -1,6 +1,8 @@
 # Create ECR Repo
 resource "aws_ecr_repository" "terraform_database" {
   name = "${var.name}/terraform"
+
+  tags = local.tags
 }
 
 resource "aws_ecr_lifecycle_policy" "terraform_database" {
@@ -31,4 +33,6 @@ resource "aws_ecr_lifecycle_policy" "terraform_database" {
 resource "aws_cloudwatch_log_group" "terraform" {
   name              = "/${var.name}/services/terraform"
   retention_in_days = var.logs.retention
+
+  tags = local.tags
 }

--- a/cluster/dns_private.tf
+++ b/cluster/dns_private.tf
@@ -8,5 +8,5 @@ resource "aws_service_discovery_private_dns_namespace" "private_dns" {
   name        = "apps.internal"
   description = "Private service discovery namespace for the ${var.name} cluster"
 
-  tags = var.tags
+  tags = local.tags
 }

--- a/cluster/dns_public.tf
+++ b/cluster/dns_public.tf
@@ -9,6 +9,8 @@ resource "aws_route53_zone" "public" {
   name = "${var.name}.${var.dns.suffix}"
 
   comment = "Delegated from Infrastructure AWS account - Managed by Terraform"
+
+  tags = local.tags
 }
 
 resource "aws_route53_record" "public_ns" {

--- a/cluster/ecs.tf
+++ b/cluster/ecs.tf
@@ -37,7 +37,7 @@ module "ecs" {
     value = "disabled"
   }
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_ssm_parameter" "cluster_arn" {
@@ -45,7 +45,7 @@ resource "aws_ssm_parameter" "cluster_arn" {
   type  = "String"
   value = module.ecs.cluster_arn
 
-  tags = var.tags
+  tags = local.tags
 }
 
 # Generic assume role policy for ECS tasks

--- a/cluster/iam_buildkite_builder.tf
+++ b/cluster/iam_buildkite_builder.tf
@@ -19,7 +19,7 @@ resource "aws_iam_role" "buildkite_builder" {
   name               = "${var.name}-BuildkiteBuilderRole"
   assume_role_policy = data.aws_iam_policy_document.buildkite_builder_assume.json
 
-  tags = var.tags
+  tags = local.tags
 }
 
 data "aws_iam_policy_document" "buildkite_ecr_push" {
@@ -59,7 +59,7 @@ resource "aws_iam_policy" "buildkite_ecr_push" {
   description = "Grants read/write access to the ECR repositories for the ${var.name} cluster"
   policy      = data.aws_iam_policy_document.buildkite_ecr_push.json
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "buildkite_ecr_push" {

--- a/cluster/iam_buildkite_deployer.tf
+++ b/cluster/iam_buildkite_deployer.tf
@@ -19,7 +19,7 @@ resource "aws_iam_role" "buildkite_deployer" {
   name               = "${var.name}-BuildkiteDeployerRole"
   assume_role_policy = data.aws_iam_policy_document.buildkite_deployer_assume.json
 
-  tags = var.tags
+  tags = local.tags
 }
 
 # Policy: Manipulate ECS tasks, services, and auto scaling
@@ -117,7 +117,7 @@ resource "aws_iam_policy" "buildkite_deploy_ecs" {
   description = "Grants read/write access to ECS tasks, services, and autoscaling for the ${var.name} cluster"
   policy      = data.aws_iam_policy_document.buildkite_deploy_ecs.json
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "buildkite_deploy_ecs" {
@@ -142,7 +142,7 @@ resource "aws_iam_policy" "buildkite_deploy_pass_cron_role" {
   policy      = data.aws_iam_policy_document.buildkite_deploy_pass_cron_role.json
   description = "Grants permission for Buildkite deployments to pass necessary ECS-related roles"
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "buildkite_deploy_pass_cron_role" {
@@ -186,7 +186,7 @@ resource "aws_iam_policy" "buildkite_deployer_terraform" {
   description = "Grants permissions needed to perform Terraform deployments"
   policy      = data.aws_iam_policy_document.buildkite_deployer_terraform.json
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "buildkite_deployer_terraform" {
@@ -229,7 +229,7 @@ resource "aws_iam_policy" "buildkite_deployer_eventbridge" {
   policy      = data.aws_iam_policy_document.buildkite_deployer_eventbridge.json
   description = "Grants read/write access to EventBridge rules for Buildkite deployment jobs"
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "buildkite_deployer_eventbridge" {

--- a/cluster/iam_cron.tf
+++ b/cluster/iam_cron.tf
@@ -14,6 +14,8 @@ resource "aws_iam_role" "cron_eventbridge" {
   name = "${var.name}-CronEventBridge"
 
   assume_role_policy = data.aws_iam_policy_document.cron_eventbridge_assume.json
+
+  tags = local.tags
 }
 
 data "aws_iam_policy_document" "cron_ecs_run_task" {
@@ -37,7 +39,7 @@ resource "aws_iam_policy" "cron_ecs_run_task" {
   name   = "${var.name}-CronRunTask"
   policy = data.aws_iam_policy_document.cron_ecs_run_task.json
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "cron_ecs_run_task" {
@@ -54,4 +56,6 @@ resource "aws_ssm_parameter" "cron_ecs_role" {
   name  = "/${var.name}/iam/eventbridge-cron"
   type  = "String"
   value = aws_iam_role.cron_eventbridge.arn
+
+  tags = local.tags
 }

--- a/cluster/iam_ecs.tf
+++ b/cluster/iam_ecs.tf
@@ -112,7 +112,7 @@ data "aws_iam_policy_document" "secrets_manager_read_only" {
     condition {
       test     = "Null"
       values   = ["true"]
-      variable = "aws:ResourceTag/f1-internal"
+      variable = "aws:ResourceTag/forumone:internal"
     }
   }
 }

--- a/cluster/iam_ecs.tf
+++ b/cluster/iam_ecs.tf
@@ -20,7 +20,7 @@ resource "aws_iam_role" "ecs_default_task" {
   description        = "Default Execution Role for ECS Tasks"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role_policy.json
 
-  tags = var.tags
+  tags = local.tags
 }
 
 # Grant non-root EFS access through access points in this VPC
@@ -75,7 +75,7 @@ resource "aws_iam_policy" "ecs_search_access" {
   description = "Grants permission to manage data in Elasticsearch/OpenSearch in the ${var.name} cluster"
   policy      = data.aws_iam_policy_document.ecs_search_access[0].json
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_search_access" {
@@ -91,7 +91,7 @@ resource "aws_iam_role" "ecs_default_exec" {
   description        = "Default Task Role for ECS Tasks"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role_policy.json
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_default_exec" {
@@ -120,6 +120,8 @@ data "aws_iam_policy_document" "secrets_manager_read_only" {
 resource "aws_iam_policy" "secrets_manager_read_only" {
   name   = "${var.name}-Task-SecretsAccess"
   policy = data.aws_iam_policy_document.secrets_manager_read_only.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "secrets_manager_read_only" {
@@ -141,6 +143,8 @@ data "aws_iam_policy_document" "parameter_store_read_only" {
 resource "aws_iam_policy" "parameter_store_read_only" {
   name   = "${var.name}-Task-ParameterAccess"
   policy = data.aws_iam_policy_document.parameter_store_read_only.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "parameter_store_read_only" {
@@ -163,6 +167,8 @@ data "aws_iam_policy_document" "env_read_only" {
 resource "aws_iam_policy" "env_read_only" {
   name   = "${var.name}-Task-S3EnvAcces"
   policy = data.aws_iam_policy_document.env_read_only.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "env_read_only" {
@@ -174,12 +180,16 @@ resource "aws_ssm_parameter" "ecs_default_task" {
   name  = "/${var.name}/iam/ecs-task"
   type  = "String"
   value = aws_iam_role.ecs_default_task.arn
+
+  tags = local.tags
 }
 
 resource "aws_ssm_parameter" "ecs_default_exec" {
   name  = "/${var.name}/iam/ecs-exec"
   type  = "String"
   value = aws_iam_role.ecs_default_exec.arn
+
+  tags = local.tags
 }
 
 # Grant access for tasks to write to cloud watch and create streams
@@ -202,6 +212,8 @@ data "aws_iam_policy_document" "cloudwatch_access" {
 resource "aws_iam_policy" "cloudwatch_access" {
   name   = "${var.name}-Task-cloudWatchAccess"
   policy = data.aws_iam_policy_document.cloudwatch_access.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "cloudwatch_access" {

--- a/cluster/iam_shared.tf
+++ b/cluster/iam_shared.tf
@@ -25,7 +25,7 @@ resource "aws_iam_policy" "ecs_pass_role" {
   description = "Grants permission to use the ECS IAM task roles for the ${var.name} cluster"
   policy      = data.aws_iam_policy_document.ecs_pass_role.json
 
-  tags = var.tags
+  tags = local.tags
 }
 
 # Automation access permissions; granted to Buildkite and exported to allow automated
@@ -79,4 +79,6 @@ resource "aws_iam_policy" "automation_access" {
   description = "Grants deployment tooling access to Systems Manager automation"
 
   policy = data.aws_iam_policy_document.automation_access.json
+
+  tags = local.tags
 }

--- a/cluster/iam_ssm_document.tf
+++ b/cluster/iam_ssm_document.tf
@@ -15,6 +15,8 @@ resource "aws_iam_role" "automation" {
   name = "${var.name}-SSM-Automation"
 
   assume_role_policy = data.aws_iam_policy_document.automation_assume.json
+
+  tags = local.tags
 }
 
 data "aws_iam_policy_document" "automation_ssm_ec2" {
@@ -100,6 +102,8 @@ resource "aws_iam_policy" "automation_ssm_ec2" {
   description = "Grants permission for Systems Manager to launch EC2 instances"
 
   policy = data.aws_iam_policy_document.automation_ssm_ec2.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "automation_ssm_ec2" {

--- a/cluster/iam_ssm_ec2.tf
+++ b/cluster/iam_ssm_ec2.tf
@@ -17,6 +17,8 @@ resource "aws_iam_role" "automation_ec2" {
   name = "${var.name}-EC2-automation"
 
   assume_role_policy = data.aws_iam_policy_document.automation_ec2_assume.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_instance_profile" "automation_ec2" {
@@ -72,6 +74,8 @@ resource "aws_iam_policy" "automation_ec2_efs" {
   description = "Grants EFS mount permission to automated EC2 instances"
 
   policy = data.aws_iam_policy_document.automation_ec2_efs.json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "automation_ec2_efs" {

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -3,3 +3,15 @@ data "aws_availability_zones" "available" {}
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
+
+locals {
+  tags = merge(var.tags, {
+    "forumone:cluster" = var.name
+  })
+
+  # Tag specification used in automation documents
+  tag_list = [
+    for key, value in local.tags :
+    { Key = key, Value = value }
+  ]
+}

--- a/cluster/memcache.tf
+++ b/cluster/memcache.tf
@@ -15,9 +15,9 @@ resource "aws_elasticache_cluster" "memcache" {
 
   port = 11211
 
-  tags = {
+  tags = merge(local.tags, {
     Name = "${var.name}-memcache"
-  }
+  })
 }
 
 # memcache default security group
@@ -26,6 +26,10 @@ resource "aws_security_group" "memcache" {
 
   name   = "${var.name}-memcache"
   vpc_id = module.vpc.vpc_id
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-memcache"
+  })
 }
 
 # Allow ingress from ECS
@@ -60,7 +64,7 @@ resource "aws_ssm_parameter" "memcache_endpoint" {
   type        = "String"
   value       = aws_elasticache_cluster.memcache[0].configuration_endpoint
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_ssm_parameter" "memcache_nodes_endpoint" {
@@ -71,5 +75,5 @@ resource "aws_ssm_parameter" "memcache_nodes_endpoint" {
   type        = "StringList"
   value       = join(",", [for node in aws_elasticache_cluster.memcache[0].cache_nodes : "${node.address}:${node.port}"])
 
-  tags = var.tags
+  tags = local.tags
 }

--- a/cluster/nlb.tf
+++ b/cluster/nlb.tf
@@ -37,7 +37,7 @@ module "nlb_log_bucket" {
     }
   ]
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_lb" "nlb" {
@@ -53,5 +53,5 @@ resource "aws_lb" "nlb" {
     enabled = true
   }
 
-  tags = var.tags
+  tags = local.tags
 }

--- a/cluster/rds_mysql.tf
+++ b/cluster/rds_mysql.tf
@@ -25,7 +25,7 @@ module "mysql" {
   apply_immediately   = true
   monitoring_interval = 5
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_secretsmanager_secret" "mysql_root_credentials" {
@@ -36,7 +36,7 @@ resource "aws_secretsmanager_secret" "mysql_root_credentials" {
 
   recovery_window_in_days = 0
 
-  tags = merge(var.tags, {
+  tags = merge(local.tags, {
     "f1-internal" = "true"
   })
 }
@@ -65,6 +65,8 @@ resource "aws_ssm_parameter" "mysql_endpoint" {
   name  = "/${var.name}/endpoints/mysql-writer"
   type  = "String"
   value = module.mysql[0].cluster_endpoint
+
+  tags = local.tags
 }
 
 resource "aws_ssm_parameter" "mysql_ro_endpoint" {
@@ -72,4 +74,6 @@ resource "aws_ssm_parameter" "mysql_ro_endpoint" {
   name  = "/${var.name}/endpoints/mysql-reader"
   type  = "String"
   value = module.mysql[0].cluster_reader_endpoint
+
+  tags = local.tags
 }

--- a/cluster/rds_mysql.tf
+++ b/cluster/rds_mysql.tf
@@ -37,7 +37,7 @@ resource "aws_secretsmanager_secret" "mysql_root_credentials" {
   recovery_window_in_days = 0
 
   tags = merge(local.tags, {
-    "f1-internal" = "true"
+    "forumone:internal" = "true"
   })
 }
 

--- a/cluster/rds_postgresql.tf
+++ b/cluster/rds_postgresql.tf
@@ -33,7 +33,7 @@ resource "aws_secretsmanager_secret" "postgresql_root_credentials" {
   recovery_window_in_days = 0
 
   tags = merge(local.tags, {
-    "f1-internal" = "true"
+    "forumone:internal" = "true"
   })
 }
 

--- a/cluster/rds_postgresql.tf
+++ b/cluster/rds_postgresql.tf
@@ -21,7 +21,7 @@ module "postgresql" {
   apply_immediately   = true
   monitoring_interval = 5
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_secretsmanager_secret" "postgresql_root_credentials" {
@@ -32,7 +32,7 @@ resource "aws_secretsmanager_secret" "postgresql_root_credentials" {
 
   recovery_window_in_days = 0
 
-  tags = merge(var.tags, {
+  tags = merge(local.tags, {
     "f1-internal" = "true"
   })
 }

--- a/cluster/redis.tf
+++ b/cluster/redis.tf
@@ -16,6 +16,8 @@ resource "aws_elasticache_replication_group" "redis" {
   port                       = 6379
   subnet_group_name          = module.vpc.elasticache_subnet_group_name
   security_group_ids         = [aws_security_group.redis[0].id]
+
+  tags = local.tags
 }
 
 # redis default Security Group
@@ -26,9 +28,9 @@ resource "aws_security_group" "redis" {
 
   vpc_id = module.vpc.vpc_id
 
-  tags = {
+  tags = merge(local.tags, {
     Name = "${var.name}-redis"
-  }
+  })
 }
 
 # Allow ingress from ECS
@@ -62,4 +64,6 @@ resource "aws_ssm_parameter" "redis" {
   description = "Redis primary endpoint address"
   type        = "String"
   value       = aws_elasticache_replication_group.redis[0].primary_endpoint_address
+
+  tags = local.tags
 }

--- a/cluster/run_task.tf
+++ b/cluster/run_task.tf
@@ -1,7 +1,7 @@
 resource "aws_ecr_repository" "run_task" {
   name = "${var.name}/run-task"
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_ecr_lifecycle_policy" "run_task" {

--- a/cluster/s3.tf
+++ b/cluster/s3.tf
@@ -34,7 +34,7 @@ module "s3_backups" {
     }
   ]
 
-  tags = var.tags
+  tags = local.tags
 }
 
 # Env file storage for ECS tasks
@@ -66,5 +66,5 @@ module "s3_env" {
     enabled = true
   }
 
-  tags = var.tags
+  tags = local.tags
 }

--- a/cluster/search.tf
+++ b/cluster/search.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_log_group" "opensearch" {
   name              = "/${var.name}/search/${each.value}"
   retention_in_days = var.logs.retention
 
-  tags = var.tags
+  tags = local.tags
 }
 
 data "aws_iam_policy_document" "opensearch_log_publish" {
@@ -43,7 +43,7 @@ resource "aws_security_group" "opensearch" {
 
   description = "Security group for Elasticsearch/OpenSearch domains"
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_security_group_rule" "opensearch_in" {
@@ -137,7 +137,7 @@ resource "aws_opensearch_domain" "opensearch" {
     }
   }
 
-  tags = var.tags
+  tags = local.tags
 
   depends_on = [aws_cloudwatch_log_resource_policy.opensearch_log_publish]
 }
@@ -149,5 +149,5 @@ resource "aws_ssm_parameter" "opensearch" {
   type  = "String"
   value = aws_opensearch_domain.opensearch[0].endpoint
 
-  tags = var.tags
+  tags = local.tags
 }

--- a/cluster/security_group_alb.tf
+++ b/cluster/security_group_alb.tf
@@ -4,9 +4,9 @@ resource "aws_security_group" "alb" {
   description = "Security group for the ALB"
   vpc_id      = module.vpc.vpc_id
 
-  tags = {
+  tags = merge(local.tags, {
     Name = "${var.name}-alb"
-  }
+  })
 }
 
 resource "aws_security_group_rule" "alb_http_in_all" {

--- a/cluster/security_group_auto_ec2.tf
+++ b/cluster/security_group_auto_ec2.tf
@@ -2,6 +2,10 @@ resource "aws_security_group" "automation_ec2" {
   name        = "${var.name}-automation-ec2"
   description = "Security group for automation EC2 instances"
   vpc_id      = module.vpc.vpc_id
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-automation-ec2"
+  })
 }
 
 # HTTP outbound is allowed primarily because some RPM-based package managers

--- a/cluster/security_group_ecs.tf
+++ b/cluster/security_group_ecs.tf
@@ -4,9 +4,9 @@ resource "aws_security_group" "ecs" {
   description = "Default group for ECS"
   vpc_id      = module.vpc.vpc_id
 
-  tags = {
+  tags = merge(local.tags, {
     Name = "${var.name}-ecs-application"
-  }
+  })
 }
 
 resource "aws_security_group_rule" "ecs_default_http_out_all" {

--- a/cluster/security_group_efs.tf
+++ b/cluster/security_group_efs.tf
@@ -3,9 +3,9 @@ resource "aws_security_group" "efs" {
   description = "Default access for ECS to EFS"
   vpc_id      = module.vpc.vpc_id
 
-  tags = {
+  tags = merge(local.tags, {
     Name = "${var.name}-efs"
-  }
+  })
 }
 
 resource "aws_security_group_rule" "ecs_default_efs_out" {

--- a/cluster/terraform.tf
+++ b/cluster/terraform.tf
@@ -26,7 +26,7 @@ module "s3_tfstate" {
     enabled = true
   }
 
-  tags = var.tags
+  tags = local.tags
 }
 
 resource "aws_dynamodb_table" "terraform_locks" {
@@ -44,5 +44,5 @@ resource "aws_dynamodb_table" "terraform_locks" {
     enabled = true
   }
 
-  tags = var.tags
+  tags = local.tags
 }

--- a/cluster/traefik-alb/README.md
+++ b/cluster/traefik-alb/README.md
@@ -64,6 +64,7 @@
 | <a name="input_configuration_file"></a> [configuration\_file](#input\_configuration\_file) | Full path to a file to be copied into S3 and read | `string` | `null` | no |
 | <a name="input_image_repository"></a> [image\_repository](#input\_image\_repository) | Image repository from which to pull Traefik. Defaults to pulling from the Docker Hub | `string` | `"traefik"` | no |
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Version tag of the Traefik container to use | `string` | `"latest"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to created resources | `map(string)` | `{}` | no |
 | <a name="input_task_cpu"></a> [task\_cpu](#input\_task\_cpu) | CPU allocation for the ECS task | `number` | `256` | no |
 | <a name="input_task_memory"></a> [task\_memory](#input\_task\_memory) | Memory allocation for the ECS task | `number` | `512` | no |
 | <a name="input_tls_policy"></a> [tls\_policy](#input\_tls\_policy) | TLS policy to apply to the HTTPS listener | `string` | `"ELBSecurityPolicy-TLS-1-2-2017-01"` | no |

--- a/cluster/traefik-alb/iam.tf
+++ b/cluster/traefik-alb/iam.tf
@@ -17,6 +17,8 @@ data "aws_iam_policy_document" "ecs_assume" {
 resource "aws_iam_role" "traefik_exec" {
   name               = "${var.ecs_cluster_name}-TraefikALBExecution"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "traefik_exec" {
@@ -28,6 +30,8 @@ resource "aws_iam_role_policy_attachment" "traefik_exec" {
 resource "aws_iam_role" "traefik_task" {
   name               = "${var.ecs_cluster_name}-TraefikALBTask"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+
+  tags = var.tags
 }
 
 data "aws_iam_policy_document" "traefik_policy" {
@@ -59,6 +63,8 @@ data "aws_iam_policy_document" "traefik_policy" {
 resource "aws_iam_policy" "traefik_policy" {
   name   = "${var.ecs_cluster_name}-TraefikALBECSAccess"
   policy = data.aws_iam_policy_document.traefik_policy.json
+
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "traefik_policy" {

--- a/cluster/traefik-alb/main.tf
+++ b/cluster/traefik-alb/main.tf
@@ -4,4 +4,6 @@ resource "aws_cloudwatch_log_group" "traefik" {
   name = "/${var.ecs_cluster_name}/services/traefik-alb"
 
   retention_in_days = var.cloudwatch_log_retention
+
+  tags = var.tags
 }

--- a/cluster/traefik-alb/s3.tf
+++ b/cluster/traefik-alb/s3.tf
@@ -21,6 +21,8 @@ module "s3_traefik" {
       }
     }
   }
+
+  tags = var.tags
 }
 
 resource "aws_s3_object" "traefik_configuration" {
@@ -33,4 +35,6 @@ resource "aws_s3_object" "traefik_configuration" {
 
   source = var.configuration_file
   etag   = filemd5(var.configuration_file)
+
+  tags = var.tags
 }

--- a/cluster/traefik-alb/security_group.tf
+++ b/cluster/traefik-alb/security_group.tf
@@ -4,9 +4,9 @@ resource "aws_security_group" "traefik" {
   description = "Security group for the Traefik reverse proxy"
   vpc_id      = var.vpc_id
 
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.ecs_cluster_name}-traefik-alb"
-  }
+  })
 }
 
 resource "aws_security_group_rule" "traefik_https_egress" {

--- a/cluster/traefik-alb/service.tf
+++ b/cluster/traefik-alb/service.tf
@@ -21,6 +21,8 @@ resource "aws_ecs_service" "traefik" {
   lifecycle {
     ignore_changes = [desired_count]
   }
+
+  tags = var.tags
 }
 
 # Create an autoscaling target for the Traefik service
@@ -32,6 +34,8 @@ resource "aws_appautoscaling_target" "traefik" {
 
   min_capacity = var.autoscaling_min
   max_capacity = var.autoscaling_max
+
+  tags = var.tags
 }
 
 # Define a CPU-based scaling policy. Autoscaling will attempt to maintain around 30% CPU

--- a/cluster/traefik-alb/target_group.tf
+++ b/cluster/traefik-alb/target_group.tf
@@ -14,6 +14,8 @@ resource "aws_lb_listener" "traefik_http" {
       status_code = "HTTP_301"
     }
   }
+
+  tags = var.tags
 }
 
 # Target group and listeners: HTTPS
@@ -29,6 +31,8 @@ resource "aws_lb_listener" "traefik_https" {
     target_group_arn = aws_lb_target_group.traefik_http.id
     type             = "forward"
   }
+
+  tags = var.tags
 }
 
 resource "aws_lb_listener_certificate" "traefik_https" {

--- a/cluster/traefik-alb/task_definition.tf
+++ b/cluster/traefik-alb/task_definition.tf
@@ -135,4 +135,6 @@ resource "aws_ecs_task_definition" "traefik" {
     # Traefik and the AWS CLI startup container.
     name = "configuration"
   }
+
+  tags = var.tags
 }

--- a/cluster/traefik-alb/variables.tf
+++ b/cluster/traefik-alb/variables.tf
@@ -106,3 +106,9 @@ variable "configuration_file" {
   type        = string
   default     = null
 }
+
+variable "tags" {
+  description = "Tags to apply to created resources"
+  type        = map(string)
+  default     = {}
+}

--- a/cluster/traefik.tf
+++ b/cluster/traefik.tf
@@ -24,6 +24,8 @@ module "traefik" {
   autoscaling_max = var.traefik.max_capacity
 
   cloudwatch_log_retention = var.logs.retention
+
+  tags = local.tags
 }
 
 # Traefik routing from behind an ALB
@@ -52,4 +54,6 @@ module "traefik_alb" {
   autoscaling_max = var.traefik.max_capacity
 
   cloudwatch_log_retention = var.logs.retention
+
+  tags = local.tags
 }

--- a/cluster/traefik/README.md
+++ b/cluster/traefik/README.md
@@ -66,6 +66,7 @@
 | <a name="input_https_port"></a> [https\_port](#input\_https\_port) | HTTPS port for Traefik to listen on | `number` | `443` | no |
 | <a name="input_image_repository"></a> [image\_repository](#input\_image\_repository) | Image repository from which to pull Traefik. Defaults to pulling from the Docker Hub | `string` | `"traefik"` | no |
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Version tag of the Traefik container to use | `string` | `"latest"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to created resources | `map(string)` | `{}` | no |
 | <a name="input_task_cpu"></a> [task\_cpu](#input\_task\_cpu) | CPU allocation for the ECS task | `number` | `256` | no |
 | <a name="input_task_memory"></a> [task\_memory](#input\_task\_memory) | Memory allocation for the ECS task | `number` | `512` | no |
 | <a name="input_tls_policy"></a> [tls\_policy](#input\_tls\_policy) | TLS policy to apply to the HTTPS listener | `string` | `"ELBSecurityPolicy-TLS-1-2-2017-01"` | no |

--- a/cluster/traefik/iam.tf
+++ b/cluster/traefik/iam.tf
@@ -16,7 +16,9 @@ data "aws_iam_policy_document" "ecs_assume" {
 # Empty execution role; Traefik does not have any need for runtime setup beyond the default
 resource "aws_iam_role" "traefik_exec" {
   name               = "${var.ecs_cluster_name}-TraefikExecution"
-  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.jsn
+
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "traefik_exec" {
@@ -28,6 +30,8 @@ resource "aws_iam_role_policy_attachment" "traefik_exec" {
 resource "aws_iam_role" "traefik_task" {
   name               = "${var.ecs_cluster_name}-TraefikTask"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+
+  tags = var.tags
 }
 
 data "aws_iam_policy_document" "traefik_policy" {
@@ -59,6 +63,8 @@ data "aws_iam_policy_document" "traefik_policy" {
 resource "aws_iam_policy" "traefik_policy" {
   name   = "${var.ecs_cluster_name}-TraefikECSAccess"
   policy = data.aws_iam_policy_document.traefik_policy.json
+
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "traefik_policy" {

--- a/cluster/traefik/main.tf
+++ b/cluster/traefik/main.tf
@@ -4,4 +4,6 @@ resource "aws_cloudwatch_log_group" "traefik" {
   name = "/${var.ecs_cluster_name}/services/traefik"
 
   retention_in_days = var.cloudwatch_log_retention
+
+  tags = var.tags
 }

--- a/cluster/traefik/s3.tf
+++ b/cluster/traefik/s3.tf
@@ -21,6 +21,8 @@ module "s3_traefik" {
       }
     }
   }
+
+  tags = var.tags
 }
 
 resource "aws_s3_object" "traefik_configuration" {
@@ -33,4 +35,6 @@ resource "aws_s3_object" "traefik_configuration" {
 
   source = var.configuration_file
   etag   = filemd5(var.configuration_file)
+
+  tags = var.tags
 }

--- a/cluster/traefik/security_group.tf
+++ b/cluster/traefik/security_group.tf
@@ -4,9 +4,9 @@ resource "aws_security_group" "traefik" {
   description = "Security group for the Traefik reverse proxy"
   vpc_id      = var.vpc_id
 
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.ecs_cluster_name}-traefik"
-  }
+  })
 }
 
 resource "aws_security_group_rule" "traefik_https_egress" {

--- a/cluster/traefik/service.tf
+++ b/cluster/traefik/service.tf
@@ -24,6 +24,8 @@ resource "aws_ecs_service" "traefik" {
     security_groups = [aws_security_group.traefik.id]
   }
 
+  tags = var.tags
+
   lifecycle {
     ignore_changes = [desired_count]
   }
@@ -38,6 +40,8 @@ resource "aws_appautoscaling_target" "traefik" {
 
   min_capacity = var.autoscaling_min
   max_capacity = var.autoscaling_max
+
+  tags = var.tags
 }
 
 # Define a CPU-based scaling policy. Autoscaling will attempt to maintain around 30% CPU

--- a/cluster/traefik/target_group.tf
+++ b/cluster/traefik/target_group.tf
@@ -15,6 +15,8 @@ resource "aws_lb_target_group" "traefik_http" {
     port     = var.http_port
     protocol = "TCP"
   }
+
+  tags = var.tags
 }
 
 resource "aws_lb_listener" "traefik_http" {
@@ -26,6 +28,8 @@ resource "aws_lb_listener" "traefik_http" {
     target_group_arn = aws_lb_target_group.traefik_http.id
     type             = "forward"
   }
+
+  tags = var.tags
 }
 
 # Target group and listeners: HTTPS
@@ -45,6 +49,8 @@ resource "aws_lb_target_group" "traefik_https" {
     port     = var.https_port
     protocol = "TCP"
   }
+
+  tags = var.tags
 }
 
 resource "aws_lb_listener" "traefik_https" {
@@ -58,6 +64,8 @@ resource "aws_lb_listener" "traefik_https" {
     target_group_arn = aws_lb_target_group.traefik_https.id
     type             = "forward"
   }
+
+  tags = var.tags
 }
 
 resource "aws_lb_listener_certificate" "traefik_https" {

--- a/cluster/traefik/task_definition.tf
+++ b/cluster/traefik/task_definition.tf
@@ -143,4 +143,6 @@ resource "aws_ecs_task_definition" "traefik" {
     # Traefik and the AWS CLI startup container.
     name = "configuration"
   }
+
+  tags = var.tags
 }

--- a/cluster/traefik/variables.tf
+++ b/cluster/traefik/variables.tf
@@ -125,3 +125,9 @@ variable "configuration_file" {
   type        = string
   default     = null
 }
+
+variable "tags" {
+  description = "Tags to apply to created resources"
+  type        = map(string)
+  default     = {}
+}

--- a/cluster/vpc.tf
+++ b/cluster/vpc.tf
@@ -40,6 +40,8 @@ module "vpc" {
   private_subnet_enable_dns64     = false
   database_subnet_enable_dns64    = false
   elasticache_subnet_enable_dns64 = false
+
+  tags = var.tags
 }
 
 module "endpoints" {
@@ -54,7 +56,9 @@ module "endpoints" {
       service_type    = "Gateway"
       route_table_ids = module.vpc.private_route_table_ids
 
-      tags = { Name = "s3-vpc-endpoint" }
+      tags = merge(local.tags, {
+        Name = "${var.name}-s3-vpc-endpoint"
+      })
     }
   }
 }
@@ -64,4 +68,6 @@ resource "aws_ssm_parameter" "private_subnets" {
   name  = "/${var.name}/vpc/private-subnets"
   type  = "StringList"
   value = join(",", module.vpc.private_subnets)
+
+  tags = local.tags
 }

--- a/tf_mysql_aurora/README.md
+++ b/tf_mysql_aurora/README.md
@@ -41,6 +41,7 @@ No modules.
 | <a name="input_mysql_credentials"></a> [mysql\_credentials](#input\_mysql\_credentials) | Username and password of the root MySQL user | <pre>object({<br>    username = string<br>    password = string<br>  })</pre> | n/a | yes |
 | <a name="input_mysql_host"></a> [mysql\_host](#input\_mysql\_host) | MySQL Host Name | `string` | n/a | yes |
 | <a name="input_mysql_port"></a> [mysql\_port](#input\_mysql\_port) | MySQL Host Port | `number` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/tf_mysql_aurora/main.tf
+++ b/tf_mysql_aurora/main.tf
@@ -42,6 +42,11 @@ resource "aws_secretsmanager_secret" "db_credentials" {
   description = "Credentials for the DB user ${each.key}"
 
   recovery_window_in_days = 0
+
+  tags = merge(var.tags, {
+    "forumone:site"        = each.value.name
+    "forumone:environment" = each.value.env
+  })
 }
 
 resource "aws_secretsmanager_secret_version" "credentials" {

--- a/tf_mysql_aurora/variables.tf
+++ b/tf_mysql_aurora/variables.tf
@@ -35,3 +35,9 @@ variable "databases" {
     db   = string
   }))
 }
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/tf_postgresql_aurora/README.md
+++ b/tf_postgresql_aurora/README.md
@@ -41,6 +41,7 @@ No modules.
 | <a name="input_postgresql_credentials"></a> [postgresql\_credentials](#input\_postgresql\_credentials) | Username and password of the root postgresql user | <pre>object({<br>    username = string<br>    password = string<br>  })</pre> | n/a | yes |
 | <a name="input_postgresql_host"></a> [postgresql\_host](#input\_postgresql\_host) | PostgreSQL Host Name | `string` | n/a | yes |
 | <a name="input_postgresql_port"></a> [postgresql\_port](#input\_postgresql\_port) | postgresql Host Port | `number` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/tf_postgresql_aurora/main.tf
+++ b/tf_postgresql_aurora/main.tf
@@ -47,6 +47,11 @@ resource "aws_secretsmanager_secret" "db_credentials" {
   description = "Credentials for the Postgresql DB user ${each.key}"
 
   recovery_window_in_days = 0
+
+  tags = merge(var.tags, {
+    "forumone:site"        = each.value.name
+    "forumone:environment" = each.value.env
+  })
 }
 
 resource "aws_secretsmanager_secret_version" "credentials" {

--- a/tf_postgresql_aurora/variables.tf
+++ b/tf_postgresql_aurora/variables.tf
@@ -35,3 +35,9 @@ variable "databases" {
     db   = string
   }))
 }
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This PR looks large but it's pretty mundane. It applies a few changes over and over again:

1. The old `f1-internal` tag has been renamed to `forumone:internal` to match our new naming scheme.
2. Instead of using `var.tags` in most places, we use a `local.tags` value to capture, at a minimum, the `forumone:cluster` tag.
3. Tags are applied in a rough hierarchy:
   1. The widest tag is `forumone:cluster`, which tags every resource as belonging to one cluster.
   2. The next is `forumone:site`, which is applied to every resource created for a site-specific purpose.
   3. The narrowest tag is `forumone:environment`, which is applied to each resource created for an environment-specific purpose.