### PR TITLE
Fix mystery typo that appeared

### DIFF
--- a/cluster/traefik/iam.tf
+++ b/cluster/traefik/iam.tf
@@ -16,7 +16,7 @@ data "aws_iam_policy_document" "ecs_assume" {
 # Empty execution role; Traefik does not have any need for runtime setup beyond the default
 resource "aws_iam_role" "traefik_exec" {
   name               = "${var.ecs_cluster_name}-TraefikExecution"
-  assume_role_policy = data.aws_iam_policy_document.ecs_assume.jsn
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
 
   tags = var.tags
 }


### PR DESCRIPTION
Not sure how this happened, but it's blocking applying tags to deployed clusters.