### PR TITLE
Allow tagging tasks on backup cron runs

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -78,8 +78,8 @@
 | [aws_iam_policy.ecs_search_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.efs_mount_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.env_read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.events_backups_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.events_backups_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.events_backups_run_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.events_backups_write_dead_letters](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.parameter_store_read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.secrets_manager_read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -122,8 +122,8 @@
 | [aws_iam_role_policy_attachment.ecs_search_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.efs_mount_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.env_read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.events_backups_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.events_backups_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.events_backups_run_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.events_backups_write_dead_letters](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.parameter_store_read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.secrets_manager_read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -240,8 +240,8 @@
 | [aws_iam_policy_document.efs_mount_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.env_read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.events_backups_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.events_backups_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.events_backups_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.events_backups_run_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.events_backups_write_dead_letters](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.opensearch_log_publish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.parameter_store_read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/cluster/backup_files.tf
+++ b/cluster/backup_files.tf
@@ -121,7 +121,9 @@ resource "aws_scheduler_schedule" "backup_files" {
       task_count          = 1
       task_definition_arn = aws_ecs_task_definition.backup_files[each.key].arn
 
-      tags = local.tags
+      tags = merge(local.tags, {
+        "forumone:site" = each.key
+      })
 
       network_configuration {
         subnets         = module.vpc.private_subnets

--- a/cluster/backups_schedule.tf
+++ b/cluster/backups_schedule.tf
@@ -68,7 +68,7 @@ resource "aws_iam_role_policy_attachment" "events_backups_write_dead_letters" {
   policy_arn = aws_iam_policy.events_backups_write_dead_letters.arn
 }
 
-data "aws_iam_policy_document" "events_backups_run_task" {
+data "aws_iam_policy_document" "events_backups_ecs" {
   version = "2012-10-17"
 
   statement {
@@ -83,16 +83,29 @@ data "aws_iam_policy_document" "events_backups_run_task" {
       values   = [module.ecs.cluster_arn]
     }
   }
+
+  statement {
+    sid       = "tagTask"
+    effect    = "Allow"
+    actions   = ["ecs:TagResource"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ecs:CreateAction"
+      values   = ["RunTask"]
+    }
+  }
 }
 
-resource "aws_iam_policy" "events_backups_run_task" {
+resource "aws_iam_policy" "events_backups_ecs" {
   name   = "${var.name}-BackupsRunTask"
-  policy = data.aws_iam_policy_document.events_backups_run_task.json
+  policy = data.aws_iam_policy_document.events_backups_ecs.json
 
   tags = local.tags
 }
 
-resource "aws_iam_role_policy_attachment" "events_backups_run_task" {
+resource "aws_iam_role_policy_attachment" "events_backups_ecs" {
   role       = aws_iam_role.events_backups.name
-  policy_arn = aws_iam_policy.events_backups_run_task.arn
+  policy_arn = aws_iam_policy.events_backups_ecs.arn
 }


### PR DESCRIPTION
This PR corrects an oversight where the backup scheduler was not permitted to apply tags to tasks.