### PR TITLE
Allow automation access by SSO users

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -274,7 +274,9 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_automation_documents"></a> [automation\_documents](#output\_automation\_documents) | ARN(s) of documents used for SSM automation |
 | <a name="output_automation_policy"></a> [automation\_policy](#output\_automation\_policy) | Name of the Systems Manager automation policy |
+| <a name="output_automation_roles"></a> [automation\_roles](#output\_automation\_roles) | ARN(s) of the roles used for SSM automation |
 | <a name="output_availability_zones"></a> [availability\_zones](#output\_availability\_zones) | List of availability zones |
 | <a name="output_buildkite_builder"></a> [buildkite\_builder](#output\_buildkite\_builder) | ARN of the Docker builder role for Buildkite to assume |
 | <a name="output_buildkite_deployer"></a> [buildkite\_deployer](#output\_buildkite\_deployer) | ARN of the Terraform deployment role for Buildkite to assume |

--- a/cluster/outputs.tf
+++ b/cluster/outputs.tf
@@ -158,3 +158,19 @@ output "postgresql_security_group_id" {
   description = "ID of the security group for the PostgreSQL database"
   value       = try(module.postgresql[0].security_group_id, null)
 }
+
+output "automation_roles" {
+  description = "ARN(s) of the roles used for SSM automation"
+  value       = [aws_iam_role.automation.arn]
+}
+
+output "automation_documents" {
+  description = "ARN(s) of documents used for SSM automation"
+
+  value = [
+    aws_ssm_document.files_export.arn,
+    aws_ssm_document.files_import.arn,
+    aws_ssm_document.mysql_export.arn,
+    aws_ssm_document.mysql_import.arn,
+  ]
+}

--- a/sso/README.md
+++ b/sso/README.md
@@ -21,10 +21,12 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.automation_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ecs_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ecs_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_ssoadmin_account_assignment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment) | resource |
+| [aws_ssoadmin_customer_managed_policy_attachment.automation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_customer_managed_policy_attachment) | resource |
 | [aws_ssoadmin_customer_managed_policy_attachment.ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_customer_managed_policy_attachment) | resource |
 | [aws_ssoadmin_customer_managed_policy_attachment.iam](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_customer_managed_policy_attachment) | resource |
 | [aws_ssoadmin_customer_managed_policy_attachment.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_customer_managed_policy_attachment) | resource |
@@ -34,6 +36,7 @@ No modules.
 | [aws_ssoadmin_managed_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_managed_policy_attachment) | resource |
 | [aws_ssoadmin_permission_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set) | resource |
 | [aws_ssoadmin_permission_set_inline_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set_inline_policy) | resource |
+| [aws_iam_policy_document.automation_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -44,6 +47,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_automation_document_arns"></a> [automation\_document\_arns](#input\_automation\_document\_arns) | ARN(s) of SSM automation documents used in this cluster | `list(string)` | n/a | yes |
+| <a name="input_automation_role_arns"></a> [automation\_role\_arns](#input\_automation\_role\_arns) | ARN(s) of automation roles for this cluster | `list(string)` | n/a | yes |
 | <a name="input_okta_group_name"></a> [okta\_group\_name](#input\_okta\_group\_name) | Name of the group (in Okta) of users who can assume this role | `string` | n/a | yes |
 | <a name="input_permission_set_name"></a> [permission\_set\_name](#input\_permission\_set\_name) | Name of the permission set (visible in the AWS SSO console) | `string` | n/a | yes |
 | <a name="input_target_account"></a> [target\_account](#input\_target\_account) | Account to which this permission set applies | `string` | n/a | yes |

--- a/sso/iam_automation.tf
+++ b/sso/iam_automation.tf
@@ -1,0 +1,23 @@
+data "aws_iam_policy_document" "automation_access" {
+  version = "2012-10-17"
+
+  statement {
+    sid       = "runAutomation"
+    effect    = "Allow"
+    actions   = ["ssm:StartAutomationExecution"]
+    resources = var.automation_document_arns
+  }
+
+  statement {
+    sid       = "getExecution"
+    effect    = "Allow"
+    actions   = ["ssm:GetAutomationExecution"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "automation_access" {
+  name_prefix = "SSO-automation-access-"
+
+  policy = data.aws_iam_policy_document.automation_access.json
+}

--- a/sso/iam_passrole.tf
+++ b/sso/iam_passrole.tf
@@ -6,7 +6,8 @@ data "aws_iam_policy_document" "ecs_pass_role" {
     effect  = "Allow"
     actions = ["iam:PassRole"]
 
-    resources = var.task_role_arns
+    # TODO: limit on iam:PassedToService conditions
+    resources = concat(var.task_role_arns, var.automation_role_arns)
   }
 }
 

--- a/sso/main.tf
+++ b/sso/main.tf
@@ -88,6 +88,7 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "s3" {
     name = aws_iam_policy.s3_access.name
     path = aws_iam_policy.s3_access.path
   }
+
   provider = aws.main
 }
 
@@ -100,11 +101,25 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "ecs" {
     name = aws_iam_policy.ecs_access.name
     path = aws_iam_policy.ecs_access.path
   }
+
   provider = aws.main
 }
 
-# In order to run tasks in the cluster(s), developers will need to pass
-# ECS-related roles
+# Developers also need access to SSM automation documents for self-service data
+# migration and exports
+resource "aws_ssoadmin_customer_managed_policy_attachment" "automation" {
+  instance_arn       = aws_ssoadmin_permission_set.this.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.this.arn
+
+  customer_managed_policy_reference {
+    name = aws_iam_policy.automation_access.name
+    path = aws_iam_policy.automation_access.path
+  }
+
+  provider = aws.main
+}
+
+# Allow passing ECS and SSM automation roles to various services
 resource "aws_ssoadmin_customer_managed_policy_attachment" "iam" {
   instance_arn       = aws_ssoadmin_permission_set.this.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.this.arn
@@ -113,6 +128,7 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "iam" {
     name = aws_iam_policy.ecs_pass_role.name
     path = aws_iam_policy.ecs_pass_role.path
   }
+
   provider = aws.main
 }
 

--- a/sso/variables.tf
+++ b/sso/variables.tf
@@ -45,6 +45,16 @@ variable "task_role_arns" {
   default     = []
 }
 
+variable "automation_role_arns" {
+  description = "ARN(s) of automation roles for this cluster"
+  type        = list(string)
+}
+
+variable "automation_document_arns" {
+  description = "ARN(s) of SSM automation documents used in this cluster"
+  type        = list(string)
+}
+
 variable "permission_set_name" {
   description = "Name of the permission set (visible in the AWS SSO console)"
   type        = string


### PR DESCRIPTION
This PR augments the SSO module to allow targeted running of some automation documents by SSO users.