### PR TITLE
Convert document ARNs into automation defintion ARNs

### DIFF
--- a/sso/iam_automation.tf
+++ b/sso/iam_automation.tf
@@ -1,11 +1,20 @@
+locals {
+  # Convert document ARNs into automation definition ARNs, as required by the StartAutomationExecution API
+  automation_definition_arns = [
+    for arn in var.automation_document_arns :
+    replace(arn, "document/", "automation-definition/")
+  ]
+}
+
 data "aws_iam_policy_document" "automation_access" {
   version = "2012-10-17"
 
   statement {
-    sid       = "runAutomation"
-    effect    = "Allow"
-    actions   = ["ssm:StartAutomationExecution"]
-    resources = var.automation_document_arns
+    sid     = "runAutomation"
+    effect  = "Allow"
+    actions = ["ssm:StartAutomationExecution"]
+
+    resources = formatlist("%s:$LATEST", local.automation_definition_arns)
   }
 
   statement {


### PR DESCRIPTION
This PR adjusts the `runAutomation` permission to reference the correct type of resource for `StartAutomationExecution`.