### PR TITLE
Fix missing EC2 instance permissions

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -104,6 +104,7 @@
 | [aws_iam_role_policy_attachment.automation_ec2_parameter_store](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.automation_ec2_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.automation_ec2_secrets_read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.automation_ec2_ssm_managed_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.automation_ssm_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.backups_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.backups_exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/cluster/auto_files_export.tf
+++ b/cluster/auto_files_export.tf
@@ -48,10 +48,11 @@ resource "aws_ssm_document" "files_export" {
         nextStep  = "RunCommandOnInstances"
 
         inputs = {
-          ImageId          = "{{ zzzInstanceAmiId }}"
-          InstanceType     = "t3a.medium"
-          SubnetId         = module.vpc.private_subnets[0]
-          SecurityGroupIds = [aws_security_group.automation_ec2.id]
+          ImageId               = "{{ zzzInstanceAmiId }}"
+          InstanceType          = "t3a.medium"
+          SubnetId              = module.vpc.private_subnets[0]
+          SecurityGroupIds      = [aws_security_group.automation_ec2.id]
+          IamInstanceProfileArn = aws_iam_instance_profile.automation_ec2.arn
 
           BlockDeviceMappings = [
             {

--- a/cluster/auto_files_import.tf
+++ b/cluster/auto_files_import.tf
@@ -55,10 +55,11 @@ resource "aws_ssm_document" "files_import" {
         nextStep  = "RunCommandOnInstances"
 
         inputs = {
-          ImageId          = "{{ zzzInstanceAmiId }}"
-          InstanceType     = "t3a.medium"
-          SubnetId         = module.vpc.private_subnets[0]
-          SecurityGroupIds = [aws_security_group.automation_ec2.id]
+          ImageId               = "{{ zzzInstanceAmiId }}"
+          InstanceType          = "t3a.medium"
+          SubnetId              = module.vpc.private_subnets[0]
+          SecurityGroupIds      = [aws_security_group.automation_ec2.id]
+          IamInstanceProfileArn = aws_iam_instance_profile.automation_ec2.arn
 
           BlockDeviceMappings = [
             {

--- a/cluster/auto_mysql_export.tf
+++ b/cluster/auto_mysql_export.tf
@@ -49,10 +49,11 @@ resource "aws_ssm_document" "mysql_export" {
         nextStep  = "RunCommandOnInstances"
 
         inputs = {
-          ImageId          = "{{ zzzInstanceAmiId }}"
-          InstanceType     = "t3a.medium"
-          SubnetId         = module.vpc.private_subnets[0]
-          SecurityGroupIds = [aws_security_group.automation_ec2.id]
+          ImageId               = "{{ zzzInstanceAmiId }}"
+          InstanceType          = "t3a.medium"
+          SubnetId              = module.vpc.private_subnets[0]
+          SecurityGroupIds      = [aws_security_group.automation_ec2.id]
+          IamInstanceProfileArn = aws_iam_instance_profile.automation_ec2.arn
 
           BlockDeviceMappings = [
             {

--- a/cluster/auto_mysql_import.tf
+++ b/cluster/auto_mysql_import.tf
@@ -56,10 +56,11 @@ resource "aws_ssm_document" "mysql_import" {
         nextStep  = "RunCommandOnInstances"
 
         inputs = {
-          ImageId          = "{{ zzzInstanceAmiId }}"
-          InstanceType     = "t3a.medium"
-          SubnetId         = module.vpc.private_subnets[0]
-          SecurityGroupIds = [aws_security_group.automation_ec2.id]
+          ImageId               = "{{ zzzInstanceAmiId }}"
+          InstanceType          = "t3a.medium"
+          SubnetId              = module.vpc.private_subnets[0]
+          SecurityGroupIds      = [aws_security_group.automation_ec2.id]
+          IamInstanceProfileArn = aws_iam_instance_profile.automation_ec2.arn
 
           BlockDeviceMappings = [
             {

--- a/cluster/iam_ssm_ec2.tf
+++ b/cluster/iam_ssm_ec2.tf
@@ -94,3 +94,9 @@ resource "aws_iam_role_policy_attachment" "automation_ec2_parameter_store" {
 
   policy_arn = aws_iam_policy.parameter_store_read_only.arn
 }
+
+resource "aws_iam_role_policy_attachment" "automation_ec2_ssm_managed_instance" {
+  role = aws_iam_role.automation_ec2.name
+
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}


### PR DESCRIPTION
This PR fixes two issues:

1. No instance profile was associated with the launched instance, and
2. No SSM permissions were assigned to the instance profile that was supposed to have been used.